### PR TITLE
AWS - Add Ec2 Instance Module

### DIFF
--- a/aws/ec2-instance/README.md
+++ b/aws/ec2-instance/README.md
@@ -22,6 +22,7 @@ No modules.
 | [aws_instance.test_instance](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/instance) | resource |
 | [aws_key_pair.deployer](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/key_pair) | resource |
 | [aws_security_group.test_group](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.out](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ssh](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
@@ -32,13 +33,19 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS Geographical Region in which to create the VPC | `string` | `"eu-west-1"` | no |
+| <a name="input_az_count"></a> [az\_count](#input\_az\_count) | The number of requested Availability Zones | `number` | `1` | no |
+| <a name="input_ec2_count"></a> [ec2\_count](#input\_ec2\_count) | The number of requested EC2 instances. | `number` | `1` | no |
+| <a name="input_egress_ip_address"></a> [egress\_ip\_address](#input\_egress\_ip\_address) | IP address to allow HTTPS access to | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_http_ingress_ip_address"></a> [http\_ingress\_ip\_address](#input\_http\_ingress\_ip\_address) | IP address to allow HTTP access from | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_https_ingress_ip_address"></a> [https\_ingress\_ip\_address](#input\_https\_ingress\_ip\_address) | IP address to allow HTTPS access from | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_instance_ami_image_id"></a> [instance\_ami\_image\_id](#input\_instance\_ami\_image\_id) | AMI image id to use for the instance. | `string` | `"ami-09e34b2574f465af6"` | no |
 | <a name="input_instance_ami_name"></a> [instance\_ami\_name](#input\_instance\_ami\_name) | AMI name to use for the instance. | `string` | `"amzn2-ami-minimal-hvm-2.0.20211001.1-arm64-ebs"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to use for the instance. | `string` | `"t2.micro"` | no |
 | <a name="input_public_key"></a> [public\_key](#input\_public\_key) | A user-provided public ssh key for use in the aws\_key\_pair resource. | `string` | n/a | yes |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description of aws security group. | `string` | n/a | yes |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of aws security group. | `string` | n/a | yes |
-| <a name="input_ssh_ip_address"></a> [ssh\_ip\_address](#input\_ssh\_ip\_address) | IP address to allow SSH access from | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_ssh_ingress_ip_address"></a> [ssh\_ingress\_ip\_address](#input\_ssh\_ingress\_ip\_address) | IP address to allow SSH access from | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data to provide as a bash script when launching the instance. Default value null. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id for use in security group. | `string` | n/a | yes |
 

--- a/aws/ec2-instance/README.md
+++ b/aws/ec2-instance/README.md
@@ -19,9 +19,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_instance.test_instance](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/instance) | resource |
+| [aws_instance.fg](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/instance) | resource |
 | [aws_key_pair.deployer](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/key_pair) | resource |
-| [aws_security_group.test_group](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
+| [aws_security_group.fg](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.out](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
@@ -37,6 +37,7 @@ No modules.
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | The number of requested Availability Zones | `number` | `1` | no |
 | <a name="input_ec2_count"></a> [ec2\_count](#input\_ec2\_count) | The number of requested EC2 instances. | `number` | `1` | no |
 | <a name="input_egress_ip_address"></a> [egress\_ip\_address](#input\_egress\_ip\_address) | IP address to allow HTTPS access to | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_env"></a> [env](#input\_env) | Environment: dev, test, stg, prod | `string` | `"dev"` | no |
 | <a name="input_http_ingress_ip_address"></a> [http\_ingress\_ip\_address](#input\_http\_ingress\_ip\_address) | IP address to allow HTTP access from | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_https_ingress_ip_address"></a> [https\_ingress\_ip\_address](#input\_https\_ingress\_ip\_address) | IP address to allow HTTPS access from | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_instance_ami_image_id"></a> [instance\_ami\_image\_id](#input\_instance\_ami\_image\_id) | AMI image id to use for the instance. | `string` | `"ami-09e34b2574f465af6"` | no |
@@ -46,12 +47,27 @@ No modules.
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description of aws security group. | `string` | n/a | yes |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of aws security group. | `string` | n/a | yes |
 | <a name="input_ssh_ingress_ip_address"></a> [ssh\_ingress\_ip\_address](#input\_ssh\_ingress\_ip\_address) | IP address to allow SSH access from | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map` | `{}` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data to provide as a bash script when launching the instance. Default value null. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id for use in security group. | `string` | n/a | yes |
+| <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC | `string` | `"test"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_instance_ids"></a> [aws\_instance\_ids](#output\_aws\_instance\_ids) | The ids of the aws ec2 instances. |
+| <a name="output_aws_instance_arns"></a> [aws\_instance\_arns](#output\_aws\_instance\_arns) | The ARNs of the aws ec2 instances. |
+| <a name="output_aws_instance_names"></a> [aws\_instance\_names](#output\_aws\_instance\_names) | A list of the aws ec2 instance names. |
+| <a name="output_key_pair_arn"></a> [key\_pair\_arn](#output\_key\_pair\_arn) | The deployer key pair ARN. |
+| <a name="output_key_pair_id"></a> [key\_pair\_id](#output\_key\_pair\_id) | The deployer key pair ID. |
+| <a name="output_key_pair_name"></a> [key\_pair\_name](#output\_key\_pair\_name) | The deployer key pair name. |
+| <a name="output_key_pair_tags"></a> [key\_pair\_tags](#output\_key\_pair\_tags) | A map of the key pair's tags, including those inherited from the provider. |
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The security group ARN. |
+| <a name="output_security_group_egress_arn"></a> [security\_group\_egress\_arn](#output\_security\_group\_egress\_arn) | The security group egress rule ARN. |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The security group ID. |
+| <a name="output_security_group_ingress_http_arn"></a> [security\_group\_ingress\_http\_arn](#output\_security\_group\_ingress\_http\_arn) | The security group ingress http rule ARN. |
+| <a name="output_security_group_ingress_https_arn"></a> [security\_group\_ingress\_https\_arn](#output\_security\_group\_ingress\_https\_arn) | The security group ingress https rule ARN. |
+| <a name="output_security_group_ingress_https_ssh"></a> [security\_group\_ingress\_https\_ssh](#output\_security\_group\_ingress\_https\_ssh) | The security group ingress ssh rule ARN. |
+| <a name="output_security_group_owner_id"></a> [security\_group\_owner\_id](#output\_security\_group\_owner\_id) | The security group owner id. |
+| <a name="output_security_group_tags"></a> [security\_group\_tags](#output\_security\_group\_tags) | A map of the security group's tags, including those inherited from the provider. |
 <!-- END_TF_DOCS -->

--- a/aws/ec2-instance/README.md
+++ b/aws/ec2-instance/README.md
@@ -1,0 +1,50 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.58.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_instance.test_instance](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/instance) | resource |
+| [aws_key_pair.deployer](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/key_pair) | resource |
+| [aws_security_group.test_group](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_ingress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ssh](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_ami.amazon-linux-2](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/ami) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/subnets) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_instance_ami_image_id"></a> [instance\_ami\_image\_id](#input\_instance\_ami\_image\_id) | AMI image id to use for the instance. | `string` | `"ami-09e34b2574f465af6"` | no |
+| <a name="input_instance_ami_name"></a> [instance\_ami\_name](#input\_instance\_ami\_name) | AMI name to use for the instance. | `string` | `"amzn2-ami-minimal-hvm-2.0.20211001.1-arm64-ebs"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to use for the instance. | `string` | `"t2.micro"` | no |
+| <a name="input_public_key"></a> [public\_key](#input\_public\_key) | A user-provided public ssh key for use in the aws\_key\_pair resource. | `string` | n/a | yes |
+| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description of aws security group. | `string` | n/a | yes |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of aws security group. | `string` | n/a | yes |
+| <a name="input_ssh_ip_address"></a> [ssh\_ip\_address](#input\_ssh\_ip\_address) | IP address to allow SSH access from | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data to provide as a bash script when launching the instance. Default value null. | `string` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id for use in security group. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_instance_ids"></a> [aws\_instance\_ids](#output\_aws\_instance\_ids) | The ids of the aws ec2 instances. |
+<!-- END_TF_DOCS -->

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -108,6 +108,11 @@ resource "aws_instance" "test_instance" {
   monitoring              = true
   user_data               = var.user_data
   vpc_security_group_ids  = [aws_security_group.test_group.id]
-  // TODO - Configure EBS fields, following discussion with Michiel.
+
+  ebs_block_device {
+    delete_on_termination = true
+    device_name           = "/dev/sda"
+  }
+
   // TODO - Create Network Interface here or create separately and assign here?
 }

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -8,7 +8,10 @@ resource "aws_key_pair" "deployer" {
   key_name   = "deployer-key"
   public_key = var.public_key
 
-  tags = var.tags
+  tags = merge(
+    { "Environment" = "${var.env}" },
+    var.tags
+  )
 }
 
 # Security Group
@@ -18,7 +21,10 @@ resource "aws_security_group" "fg" {
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
-  tags = var.tags
+  tags = merge(
+    { "Environment" = "${var.env}" },
+    var.tags
+  )
 }
 
 ## Ingress Rules
@@ -33,7 +39,7 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
   cidr_ipv4   = var.https_ingress_ip_address
 
   tags = merge(
-    { "Name" = "${var.security_group_name}-ingress-https" },
+    { "Name" = "${var.security_group_name}-ingress-https", "Environment" = "${var.env}" },
     var.tags
   )
 }
@@ -48,7 +54,7 @@ resource "aws_vpc_security_group_ingress_rule" "http" {
   cidr_ipv4   = var.http_ingress_ip_address
 
   tags = merge(
-    { "Name" = "${var.security_group_name}-ingress-http" },
+    { "Name" = "${var.security_group_name}-ingress-http", "Environment" = "${var.env}" },
     var.tags
   )
 }
@@ -63,7 +69,7 @@ resource "aws_vpc_security_group_ingress_rule" "ssh" {
   cidr_ipv4   = var.ssh_ingress_ip_address
 
   tags = merge(
-    { "Name" = "${var.security_group_name}-ingress-ssh" },
+    { "Name" = "${var.security_group_name}-ingress-ssh", "Environment" = "${var.env}" },
     var.tags
   )
 }
@@ -80,7 +86,7 @@ resource "aws_vpc_security_group_egress_rule" "out" {
   cidr_ipv4   = var.egress_ip_address
 
   tags = merge(
-    { "Name" = "${var.security_group_name}-egress" },
+    { "Name" = "${var.security_group_name}-egress", "Environment" = "${var.env}" },
     var.tags
   )
 }
@@ -141,7 +147,7 @@ resource "aws_instance" "fg" {
 
 
   tags = merge(
-    { "Name" = "${var.vpc_name}-ec2-instance-${count.index + 1}" },
+    { "Name" = "${var.vpc_name}-ec2-instance-${count.index + 1}", "Environment" = "${var.env}" },
     var.tags
   )
 

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -11,7 +11,7 @@ resource "aws_key_pair" "deployer" {
 
 # Security Group
 
-resource "aws_security_group" "test_group" {
+resource "aws_security_group" "fg" {
   name        = var.security_group_name
   description = var.security_group_description
   vpc_id      = var.vpc_id
@@ -20,7 +20,7 @@ resource "aws_security_group" "test_group" {
 ## Ingress Rules
 
 resource "aws_vpc_security_group_ingress_rule" "https" {
-  security_group_id = aws_security_group.test_group.id
+  security_group_id = aws_security_group.fg.id
 
   description = "HTTPS ingress"
   from_port   = 443
@@ -30,7 +30,7 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http" {
-  security_group_id = aws_security_group.test_group.id
+  security_group_id = aws_security_group.fg.id
 
   description = "HTTP ingress"
   from_port   = 80
@@ -40,7 +40,7 @@ resource "aws_vpc_security_group_ingress_rule" "http" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ssh" {
-  security_group_id = aws_security_group.test_group.id
+  security_group_id = aws_security_group.fg.id
 
   description = "SSH ingress"
   from_port   = 22
@@ -52,7 +52,7 @@ resource "aws_vpc_security_group_ingress_rule" "ssh" {
 ## Egress Rule:
 
 resource "aws_vpc_security_group_egress_rule" "out" {
-  security_group_id = aws_security_group.test_group.id
+  security_group_id = aws_security_group.fg.id
 
   description = "Security group egress"
   from_port   = 0
@@ -95,7 +95,7 @@ data "aws_subnets" "private" {
   }
 }
 
-resource "aws_instance" "test_instance" {
+resource "aws_instance" "fg" {
   count = var.ec2_count
   // Uses modulo operator to spread ec2 instances through configured number of subnets.
   subnet_id = data.aws_subnets.private.ids[count.index % var.az_count]
@@ -108,7 +108,7 @@ resource "aws_instance" "test_instance" {
   disable_api_termination = false
   monitoring              = true
   user_data               = var.user_data
-  vpc_security_group_ids  = [aws_security_group.test_group.id]
+  vpc_security_group_ids  = [aws_security_group.fg.id]
 
   ebs_block_device {
     delete_on_termination = true

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -98,7 +98,8 @@ data "aws_subnets" "private" {
 resource "aws_instance" "test_instance" {
   count = var.ec2_count
   // Uses modulo operator to spread ec2 instances through configured number of subnets.
-  subnet_id                   = data.aws_subnets.private.ids[count.index % var.az_count]
+  subnet_id = data.aws_subnets.private.ids[count.index % var.az_count]
+  // Do we need to account for the case where the above array is empty? Or will it always be populated in production?
   ami                         = data.aws_ami.amazon-linux-2.id
   instance_type               = var.instance_type
   associate_public_ip_address = false

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -115,7 +115,7 @@ data "aws_subnets" "private" {
   }
 
   tags = {
-    Tier = "Private"
+    Name = "*private*"
   }
 }
 

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -128,8 +128,7 @@ data "aws_subnets" "private" {
 resource "aws_instance" "fg" {
   count = var.ec2_count
   // Uses modulo operator to spread ec2 instances through configured number of subnets.
-  subnet_id = data.aws_subnets.private.ids[count.index % var.az_count]
-  // Do we need to account for the case where the above array is empty? Or will it always be populated in production/usage?
+  subnet_id                   = data.aws_subnets.private.ids[count.index % var.az_count]
   ami                         = data.aws_ami.amazon-linux-2.id
   instance_type               = var.instance_type
   associate_public_ip_address = false

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -7,12 +7,13 @@ resource "aws_key_pair" "deployer" {
 
 # Security Group
 
-// TODO - Add outbound egress rules?
 resource "aws_security_group" "test_group" {
   name        = var.security_group_name
   description = var.security_group_description
   vpc_id      = var.vpc_id
 }
+
+## Ingress Rules
 
 resource "aws_vpc_security_group_ingress_rule" "https" {
   security_group_id = aws_security_group.test_group.id
@@ -21,8 +22,7 @@ resource "aws_vpc_security_group_ingress_rule" "https" {
   from_port   = 443
   to_port     = 443
   ip_protocol = "tcp"
-  cidr_ipv4   = "10.0.0.0/16"
-  // is this the correct IP?
+  cidr_ipv4   = var.https_ingress_ip_address
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http" {
@@ -32,8 +32,7 @@ resource "aws_vpc_security_group_ingress_rule" "http" {
   from_port   = 80
   to_port     = 80
   ip_protocol = "tcp"
-  cidr_ipv4   = "10.0.0.0/16"
-  // is this the correct IP?
+  cidr_ipv4   = var.http_ingress_ip_address
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ssh" {
@@ -43,7 +42,19 @@ resource "aws_vpc_security_group_ingress_rule" "ssh" {
   from_port   = 22
   to_port     = 22
   ip_protocol = "tcp"
-  cidr_ipv4   = var.ssh_ip_address
+  cidr_ipv4   = var.ssh_ingress_ip_address
+}
+
+## Egress Rule:
+
+resource "aws_vpc_security_group_egress_rule" "out" {
+  security_group_id = aws_security_group.test_group.id
+
+  description = "Security group egress"
+  from_port   = 0
+  to_port     = 0
+  ip_protocol = "-1"
+  cidr_ipv4   = var.egress_ip_address
 }
 
 # EC2 Instance

--- a/aws/ec2-instance/outputs.tf
+++ b/aws/ec2-instance/outputs.tf
@@ -1,0 +1,5 @@
+output "aws_instance_ids" {
+  value       = [for s in aws_instance.test_instance : s.id]
+  description = "The ids of the aws ec2 instances."
+}
+

--- a/aws/ec2-instance/outputs.tf
+++ b/aws/ec2-instance/outputs.tf
@@ -1,5 +1,5 @@
 output "aws_instance_ids" {
-  value       = [for s in aws_instance.test_instance : s.id]
+  value       = [for s in aws_instance.fg : s.id]
   description = "The ids of the aws ec2 instances."
 }
 

--- a/aws/ec2-instance/outputs.tf
+++ b/aws/ec2-instance/outputs.tf
@@ -1,5 +1,77 @@
-output "aws_instance_ids" {
-  value       = [for s in aws_instance.fg : s.id]
-  description = "The ids of the aws ec2 instances."
+# AWS EC2 Instance
+
+output "aws_instance_arns" {
+  value       = compact([for s in aws_instance.fg : s.arn])
+  description = "The ARNs of the aws ec2 instances."
+}
+
+output "aws_instance_names" {
+  value       = compact([for i in aws_instance.fg : i.tags.Name])
+  description = "A list of the aws ec2 instance names."
+}
+
+# Key Pair
+
+output "key_pair_name" {
+  value       = try(aws_key_pair.deployer.key_name, "")
+  description = "The deployer key pair name."
+}
+
+output "key_pair_arn" {
+  value       = try(aws_key_pair.deployer.arn, "")
+  description = "The deployer key pair ARN."
+}
+
+output "key_pair_id" {
+  value       = try(aws_key_pair.deployer.key_pair_id, "")
+  description = "The deployer key pair ID."
+}
+
+output "key_pair_tags" {
+  value       = try(aws_key_pair.deployer.tags_all, {})
+  description = "A map of the key pair's tags, including those inherited from the provider."
+}
+
+# Security Group
+
+
+output "security_group_owner_id" {
+  value       = try(aws_security_group.fg.owner_id, "")
+  description = "The security group owner id."
+}
+
+output "security_group_arn" {
+  value       = try(aws_security_group.fg.arn, "")
+  description = "The security group ARN."
+}
+
+output "security_group_id" {
+  value       = try(aws_security_group.fg.id, "")
+  description = "The security group ID."
+}
+
+output "security_group_tags" {
+  value       = try(aws_security_group.fg.tags_all, {})
+  description = "A map of the security group's tags, including those inherited from the provider."
+}
+
+output "security_group_ingress_https_arn" {
+  value       = try(aws_vpc_security_group_ingress_rule.https.arn, "")
+  description = "The security group ingress https rule ARN."
+}
+
+output "security_group_ingress_http_arn" {
+  value       = try(aws_vpc_security_group_ingress_rule.http.arn, "")
+  description = "The security group ingress http rule ARN."
+}
+
+output "security_group_ingress_https_ssh" {
+  value       = try(aws_vpc_security_group_ingress_rule.ssh.arn, "")
+  description = "The security group ingress ssh rule ARN."
+}
+
+output "security_group_egress_arn" {
+  value       = try(aws_vpc_security_group_egress_rule.out.arn, "")
+  description = "The security group egress rule ARN."
 }
 

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -97,3 +97,13 @@ variable "az_count" {
   description = "The number of requested Availability Zones"
   default     = 1
 }
+
+variable "vpc_name" {
+  description = "Name of the VPC"
+  default     = "test"
+}
+
+variable "tags" {
+  description = ""
+  default     = {}
+}

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -52,6 +52,12 @@ variable "egress_ip_address" {
 
 # EC2 Instance
 
+variable "ec2_count" {
+  type        = number
+  description = "The number of requested EC2 instances."
+  default     = 1
+}
+
 // Hard-coded arbitrary ami image details for now - could provide user with a map of defaults?
 variable "instance_ami_name" {
   type        = string
@@ -76,4 +82,18 @@ variable "user_data" {
   type        = string
   description = "User data to provide as a bash script when launching the instance. Default value null."
   default     = null
+}
+
+# Availability Zones
+
+variable "aws_region" {
+  type        = string
+  description = "The AWS Geographical Region in which to create the VPC"
+  default     = "eu-west-1"
+}
+
+variable "az_count" {
+  type        = number
+  description = "The number of requested Availability Zones"
+  default     = 1
 }

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -1,0 +1,57 @@
+# Key Pair
+
+variable "public_key" {
+  type        = string
+  description = "A user-provided public ssh key for use in the aws_key_pair resource."
+}
+
+# Security Group
+
+variable "security_group_name" {
+  type        = string
+  description = "Name of aws security group."
+}
+
+variable "security_group_description" {
+  type        = string
+  description = "Description of aws security group."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC id for use in security group."
+}
+
+variable "ssh_ip_address" {
+  type        = string
+  description = "IP address to allow SSH access from"
+  default     = "0.0.0.0/0"
+}
+
+# EC2 Instance
+
+// Hard-coded arbitrary ami image details for now - could provide user with a map of defaults?
+variable "instance_ami_name" {
+  type        = string
+  description = "AMI name to use for the instance."
+  default     = "amzn2-ami-minimal-hvm-2.0.20211001.1-arm64-ebs"
+}
+
+variable "instance_ami_image_id" {
+  type        = string
+  description = "AMI image id to use for the instance."
+  default     = "ami-09e34b2574f465af6"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "Instance type to use for the instance."
+  // Hard-coded arbitrary value for now - update with more appropriate default.
+  default = "t2.micro"
+}
+
+variable "user_data" {
+  type        = string
+  description = "User data to provide as a bash script when launching the instance. Default value null."
+  default     = null
+}

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -22,10 +22,32 @@ variable "vpc_id" {
   description = "VPC id for use in security group."
 }
 
-variable "ssh_ip_address" {
+## Ingress rules
+
+variable "https_ingress_ip_address" {
+  type        = string
+  description = "IP address to allow HTTPS access from"
+  default     = "10.0.0.0/16"
+}
+
+variable "http_ingress_ip_address" {
+  type        = string
+  description = "IP address to allow HTTP access from"
+  default     = "10.0.0.0/16"
+}
+
+variable "ssh_ingress_ip_address" {
   type        = string
   description = "IP address to allow SSH access from"
   default     = "0.0.0.0/0"
+}
+
+## Egress rules
+
+variable "egress_ip_address" {
+  type        = string
+  description = "IP address to allow HTTPS access to"
+  default     = "10.0.0.0/16"
 }
 
 # EC2 Instance

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -107,3 +107,9 @@ variable "tags" {
   description = ""
   default     = {}
 }
+
+variable "env" {
+  description = "Environment: dev, test, stg, prod"
+  type        = string
+  default     = "dev"
+}

--- a/aws/ec2-instance/versions.tf
+++ b/aws/ec2-instance/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.58.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a terraform module for creating an ec2 instance in AWS.

I have currently opted to loop through all private subnets, putting instances across all availability zones; if we would prefer to grab just one subnet from the VPC, this will need to be changed.

I have also picked two arbitrary values for the instance_type and ami variables - have left comments here in case they need updating with more appropriate values.

Remaining TODOs:
- Assign Network Interface to aws_instance resource.