### PR TITLE
AWS - Fix - EC2 Usage

### DIFF
--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -76,7 +76,7 @@ resource "aws_vpc_security_group_egress_rule" "out" {
   description = "Security group egress"
   from_port   = 0
   to_port     = 0
-  ip_protocol = "-1"
+  ip_protocol = -1
   cidr_ipv4   = var.egress_ip_address
 
   tags = merge(

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -74,9 +74,9 @@ resource "aws_vpc_security_group_egress_rule" "out" {
   security_group_id = aws_security_group.fg.id
 
   description = "Security group egress"
-  from_port   = 0
-  to_port     = 0
-  ip_protocol = -1
+  from_port   = -1
+  to_port     = -1
+  ip_protocol = "-1"
   cidr_ipv4   = var.egress_ip_address
 
   tags = merge(

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -138,12 +138,6 @@ resource "aws_instance" "fg" {
   user_data               = var.user_data
   vpc_security_group_ids  = [aws_security_group.fg.id]
 
-  ebs_block_device {
-    delete_on_termination = true
-    device_name           = "/dev/sda1"
-  }
-
-
   tags = merge(
     { "Name" = "${var.vpc_name}-ec2-instance-${count.index + 1}-${var.env}", },
     var.tags

--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -135,7 +135,7 @@ resource "aws_instance" "fg" {
 
   ebs_block_device {
     delete_on_termination = true
-    device_name           = "/dev/sda"
+    device_name           = "/dev/sda1"
   }
 
 

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -62,13 +62,13 @@ variable "ec2_count" {
 variable "instance_ami_name" {
   type        = string
   description = "AMI name to use for the instance."
-  default     = "amzn2-ami-minimal-hvm-2.0.20211001.1-arm64-ebs"
+  default     = "amzn2-ami-minimal-hvm-2.0.20210813.1-x86_64-ebs"
 }
 
 variable "instance_ami_image_id" {
   type        = string
   description = "AMI image id to use for the instance."
-  default     = "ami-09e34b2574f465af6"
+  default     = "ami-0ae3d9398717c94fb"
 }
 
 variable "instance_type" {

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -86,12 +86,6 @@ variable "user_data" {
 
 # Availability Zones
 
-variable "aws_region" {
-  type        = string
-  description = "The AWS Geographical Region in which to create the VPC"
-  default     = "eu-west-1"
-}
-
 variable "az_count" {
   type        = number
   description = "The number of requested Availability Zones"


### PR DESCRIPTION
Fixes to the ec2 module, discovered during testing in the dev sandbox.
- Remove additional ebs block (root block is already created with instance).
- Change instance egress rule to prevent error (ports 0 -> -1).
- Use data sources instead of locals to distribute AZs and subnets, ensuring that they match up.
- Update default ami to match instance_type architecture. 