### PR TITLE
AWS - Web ACL for an Application Load Balancer

### DIFF
--- a/aws/app-lb/README.md
+++ b/aws/app-lb/README.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
@@ -23,6 +23,7 @@ No modules.
 | [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_s3_bucket.fg_alb_access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_security_group.default_fg_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
@@ -38,17 +39,18 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb_name"></a> [alb\_name](#input\_alb\_name) | Name of the Application Load Balancer. | `string` | n/a | yes |
-| <a name="input_alb_security_group_ids"></a> [alb\_security\_group\_ids](#input\_alb\_security\_group\_ids) | List of additional Security Group IDs for ALB. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_alb_security_group_ids"></a> [alb\_security\_group\_ids](#input\_alb\_security\_group\_ids) | List of additional Security Group IDs for ALB. | `list(string)` | `[]` | no |
 | <a name="input_alb_type_internal"></a> [alb\_type\_internal](#input\_alb\_type\_internal) | Boolean to specify whether type of ALB is internal. True == internal; false == external. | `bool` | `true` | no |
-| <a name="input_cert_domain_name"></a> [cert\_domain\_name](#input\_cert\_domain\_name) | Domain name for which the certificate should be issued. | `string` | n/a | yes |
+| <a name="input_cert_domain_name"></a> [cert\_domain\_name](#input\_cert\_domain\_name) | Domain name for which the certificate should be issued. | `string` | `"test.com"` | no |
 | <a name="input_cert_key_algorithm"></a> [cert\_key\_algorithm](#input\_cert\_key\_algorithm) | The algorithm of the public and private key pair that the Amazon-issued certificate uses to encrypt data. | `string` | `"RSA_2048"` | no |
 | <a name="input_cert_validation_method"></a> [cert\_validation\_method](#input\_cert\_validation\_method) | The validation method used to approve ACM certificate used in ALB - DNS, EMAIL, or NONE are valid values. | `string` | `"EMAIL"` | no |
 | <a name="input_egress_ip_address"></a> [egress\_ip\_address](#input\_egress\_ip\_address) | IP address to allow HTTP access to. | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_enable_access_logging"></a> [enable\_access\_logging](#input\_enable\_access\_logging) | Boolean to specify whether to store access logs for the ALB. | `bool` | n/a | yes |
 | <a name="input_enable_internal_alb_tls"></a> [enable\_internal\_alb\_tls](#input\_enable\_internal\_alb\_tls) | Boolean to specify whether to enable TLS for the Internal Application Load Balancer. (External ALB has TLS enabled by default.) | `bool` | `false` | no |
 | <a name="input_external_internet_ingress_ip_address"></a> [external\_internet\_ingress\_ip\_address](#input\_external\_internet\_ingress\_ip\_address) | IP address to allow external ALB HTTPS access from. | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_health_check"></a> [health\_check](#input\_health\_check) | Map describing Health Check settings - including endpoint (default /) and port (default 80). | `map(string)` | <pre>{<br>  "healthy_threshold": "3",<br>  "interval": "20",<br>  "matcher": "200",<br>  "path": "/",<br>  "port": "80",<br>  "protocol": "HTTP",<br>  "timeout": "10",<br>  "unhealthy_threshold": "2"<br>}</pre> | no |
 | <a name="input_internal_ingress_ip_address"></a> [internal\_ingress\_ip\_address](#input\_internal\_ingress\_ip\_address) | IP address to allow internal ALB access from. | `string` | `"10.0.0.0/16"` | no |
-| <a name="input_s3_bucket_id"></a> [s3\_bucket\_id](#input\_s3\_bucket\_id) | ID of the S3 bucket used to store the logs in. | `string` | n/a | yes |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket to store the logs in. If none is passed in by user, a new S3 bucket will be created. | `string` | `""` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of aws security group. | `string` | n/a | yes |
 | <a name="input_ssl_cert"></a> [ssl\_cert](#input\_ssl\_cert) | Optional ARN of custom SSL server certificate. If this field is not specified module will create an Amazon-issued ACM certificate. | `string` | `null` | no |
 | <a name="input_ssl_security_policy"></a> [ssl\_security\_policy](#input\_ssl\_security\_policy) | Name of SSL Policy for internal HTTPS listener. | `string` | `"ELBSecurityPolicy-2016-08"` | no |

--- a/aws/ec2-instance/README.md
+++ b/aws/ec2-instance/README.md
@@ -27,21 +27,21 @@ No modules.
 | [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.ssh](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_ami.amazon-linux-2](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/ami) | data source |
-| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/subnets) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/availability_zones) | data source |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS Geographical Region in which to create the VPC | `string` | `"eu-west-1"` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | The number of requested Availability Zones | `number` | `1` | no |
 | <a name="input_ec2_count"></a> [ec2\_count](#input\_ec2\_count) | The number of requested EC2 instances. | `number` | `1` | no |
 | <a name="input_egress_ip_address"></a> [egress\_ip\_address](#input\_egress\_ip\_address) | IP address to allow HTTPS access to | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment: dev, test, stg, prod | `string` | `"dev"` | no |
 | <a name="input_http_ingress_ip_address"></a> [http\_ingress\_ip\_address](#input\_http\_ingress\_ip\_address) | IP address to allow HTTP access from | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_https_ingress_ip_address"></a> [https\_ingress\_ip\_address](#input\_https\_ingress\_ip\_address) | IP address to allow HTTPS access from | `string` | `"10.0.0.0/16"` | no |
-| <a name="input_instance_ami_image_id"></a> [instance\_ami\_image\_id](#input\_instance\_ami\_image\_id) | AMI image id to use for the instance. | `string` | `"ami-09e34b2574f465af6"` | no |
-| <a name="input_instance_ami_name"></a> [instance\_ami\_name](#input\_instance\_ami\_name) | AMI name to use for the instance. | `string` | `"amzn2-ami-minimal-hvm-2.0.20211001.1-arm64-ebs"` | no |
+| <a name="input_instance_ami_image_id"></a> [instance\_ami\_image\_id](#input\_instance\_ami\_image\_id) | AMI image id to use for the instance. | `string` | `"ami-0ae3d9398717c94fb"` | no |
+| <a name="input_instance_ami_name"></a> [instance\_ami\_name](#input\_instance\_ami\_name) | AMI name to use for the instance. | `string` | `"amzn2-ami-minimal-hvm-2.0.20210813.1-x86_64-ebs"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to use for the instance. | `string` | `"t2.micro"` | no |
 | <a name="input_public_key"></a> [public\_key](#input\_public\_key) | A user-provided public ssh key for use in the aws\_key\_pair resource. | `string` | n/a | yes |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description of aws security group. | `string` | n/a | yes |

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -20,8 +20,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_internet_gateway.default](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/internet_gateway) | resource |
-| [aws_network_acl.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/network_acl) | resource |
-| [aws_network_acl.public_subnets](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/network_acl) | resource |
 | [aws_route.public](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/route) | resource |
 | [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/route_table) | resource |
 | [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/route_table) | resource |
@@ -46,18 +44,18 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The number of Availability Zones to create | `number` | `1` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS Geographycal Region in which to create the VPC | `string` | `"eu-west-1"` | no |
-| <a name="input_dhcp_dns_servers"></a> [dhcp\_dns\_servers](#input\_dhcp\_dns\_servers) | DNS servers for the instances within the VPC | `list` | <pre>[<br>  "AmazonProvidedDNS"<br>]</pre> | no |
+| <a name="input_dhcp_dns_servers"></a> [dhcp\_dns\_servers](#input\_dhcp\_dns\_servers) | DNS servers for the instances within the VPC | `list(any)` | <pre>[<br>  "AmazonProvidedDNS"<br>]</pre> | no |
 | <a name="input_dhcp_domain_name"></a> [dhcp\_domain\_name](#input\_dhcp\_domain\_name) | Suffix domain name by default | `string` | `""` | no |
-| <a name="input_dhcp_netbios_name_servers"></a> [dhcp\_netbios\_name\_servers](#input\_dhcp\_netbios\_name\_servers) | For Windows Instances: The friendly name assigned to an instance | `list` | `[]` | no |
+| <a name="input_dhcp_netbios_name_servers"></a> [dhcp\_netbios\_name\_servers](#input\_dhcp\_netbios\_name\_servers) | For Windows Instances: The friendly name assigned to an instance | `list(any)` | `[]` | no |
 | <a name="input_dhcp_netbios_node_type"></a> [dhcp\_netbios\_node\_type](#input\_dhcp\_netbios\_node\_type) | For Windows Instances: how the instance will resolve netbios names to IP addresses | `number` | `2` | no |
-| <a name="input_dhcp_ntp_servers"></a> [dhcp\_ntp\_servers](#input\_dhcp\_ntp\_servers) | NTP servers for the instances within the VPC | `list` | `[]` | no |
+| <a name="input_dhcp_ntp_servers"></a> [dhcp\_ntp\_servers](#input\_dhcp\_ntp\_servers) | NTP servers for the instances within the VPC | `list(any)` | `[]` | no |
 | <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | Enable assigning DNS hostnames to instances with public IP address | `bool` | `false` | no |
 | <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | Enable asigning internal DNS hostnames through AWS provided DNS server | `bool` | `true` | no |
 | <a name="input_enable_internet_gateway"></a> [enable\_internet\_gateway](#input\_enable\_internet\_gateway) | Allow the public subnets to have access to the internet | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment of the VPC: dev, test, stg, prod | `string` | `"dev"` | no |
 | <a name="input_instance_tenancy"></a> [instance\_tenancy](#input\_instance\_tenancy) | Ensures that EC2 instances use the tenancy specified with launching | `string` | `"default"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `string` | `""` | no |
-| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR of the VPC, we are starting with a /16 | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Useful to diferentiate resources per env, team, function ... | `map(any)` | `{}` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR of the VPC, we are starting with a /16 | `string` | `"10.10.0.0/16"` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC | `string` | `"test"` | no |
 
 ## Outputs
@@ -83,4 +81,5 @@ No modules.
 | <a name="output_vpc_instance_tenancy"></a> [vpc\_instance\_tenancy](#output\_vpc\_instance\_tenancy) | Tenancy of instances spin up within VPC |
 | <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with fg\_vpc VPC |
 | <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC |
+| <a name="output_vpc_tags"></a> [vpc\_tags](#output\_vpc\_tags) | Map with all the tags for the VPC |
 <!-- END_TF_DOCS -->

--- a/aws/waf-acl-alb/README.md
+++ b/aws/waf-acl-alb/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_wafv2_web_acl.fg_web_acl_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl_association.fg_waf_to_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_logging_configuration.fg_logging_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | ARN of the Application LB to associate with | `string` | n/a | yes |
+| <a name="input_custom_responses"></a> [custom\_responses](#input\_custom\_responses) | The custom response behaviour for the default web ACL action | <pre>list(object({<br>    key          = string<br>    content      = string<br>    content_type = string<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_rules"></a> [custom\_rules](#input\_custom\_rules) | Add here all the rules as a list of maps | `list(string)` | `[]` | no |
+| <a name="input_default_action"></a> [default\_action](#input\_default\_action) | Action to apply if no rules match | `string` | `"allow"` | no |
+| <a name="input_description"></a> [description](#input\_description) | Something meaningful to describe this ACL | `string` | n/a | yes |
+| <a name="input_enable_cloudwatch"></a> [enable\_cloudwatch](#input\_enable\_cloudwatch) | Enable metrics for the ACL | `bool` | `true` | no |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Log all traffic through the ACL | `bool` | `false` | no |
+| <a name="input_enable_sampled_requests"></a> [enable\_sampled\_requests](#input\_enable\_sampled\_requests) | Enable sampled requests for the ACL | `bool` | `true` | no |
+| <a name="input_managed_rules"></a> [managed\_rules](#input\_managed\_rules) | List of Managed WAF rules. | <pre>list(object({<br>    name            = string<br>    priority        = number<br>    override_action = string<br>    excluded_rules  = list(string)<br>    vendor_name     = string<br>  }))</pre> | <pre>[<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesCommonRuleSet",<br>    "override_action": "none",<br>    "priority": 10,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesAmazonIpReputationList",<br>    "override_action": "none",<br>    "priority": 20,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesKnownBadInputsRuleSet",<br>    "override_action": "none",<br>    "priority": 30,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesSQLiRuleSet",<br>    "override_action": "none",<br>    "priority": 40,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesLinuxRuleSet",<br>    "override_action": "none",<br>    "priority": 50,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesUnixRuleSet",<br>    "override_action": "none",<br>    "priority": 60,<br>    "vendor_name": "AWS"<br>  }<br>]</pre> | no |
+| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | The name of the metric to create, if we are enabling CloudWatch | `string` | `"FG_WEBACL_ALB_Entityx"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the WEB ACL | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Useful to diferentiate resources per env, team, function ... | `map(any)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_web_acl_arn"></a> [web\_acl\_arn](#output\_web\_acl\_arn) | n/a |
+| <a name="output_web_acl_capacity"></a> [web\_acl\_capacity](#output\_web\_acl\_capacity) | n/a |
+| <a name="output_web_acl_id"></a> [web\_acl\_id](#output\_web\_acl\_id) | n/a |
+| <a name="output_web_acl_tags"></a> [web\_acl\_tags](#output\_web\_acl\_tags) | n/a |
+<!-- END_TF_DOCS -->

--- a/aws/waf-acl-alb/README.md
+++ b/aws/waf-acl-alb/README.md
@@ -1,13 +1,16 @@
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.58.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
 
 ## Modules
 
@@ -17,9 +20,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_wafv2_web_acl.fg_web_acl_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
-| [aws_wafv2_web_acl_association.fg_waf_to_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
-| [aws_wafv2_web_acl_logging_configuration.fg_logging_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+| [aws_wafv2_web_acl.fg_web_acl_alb](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl_association.fg_waf_to_alb](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_logging_configuration.fg_logging_waf](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 
 ## Inputs
 
@@ -27,15 +30,19 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | ARN of the Application LB to associate with | `string` | n/a | yes |
 | <a name="input_custom_responses"></a> [custom\_responses](#input\_custom\_responses) | The custom response behaviour for the default web ACL action | <pre>list(object({<br>    key          = string<br>    content      = string<br>    content_type = string<br>  }))</pre> | `[]` | no |
-| <a name="input_custom_rules"></a> [custom\_rules](#input\_custom\_rules) | Add here all the rules as a list of maps | `list(string)` | `[]` | no |
 | <a name="input_default_action"></a> [default\_action](#input\_default\_action) | Action to apply if no rules match | `string` | `"allow"` | no |
 | <a name="input_description"></a> [description](#input\_description) | Something meaningful to describe this ACL | `string` | n/a | yes |
 | <a name="input_enable_cloudwatch"></a> [enable\_cloudwatch](#input\_enable\_cloudwatch) | Enable metrics for the ACL | `bool` | `true` | no |
 | <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Log all traffic through the ACL | `bool` | `false` | no |
 | <a name="input_enable_sampled_requests"></a> [enable\_sampled\_requests](#input\_enable\_sampled\_requests) | Enable sampled requests for the ACL | `bool` | `true` | no |
-| <a name="input_managed_rules"></a> [managed\_rules](#input\_managed\_rules) | List of Managed WAF rules. | <pre>list(object({<br>    name            = string<br>    priority        = number<br>    override_action = string<br>    excluded_rules  = list(string)<br>    vendor_name     = string<br>  }))</pre> | <pre>[<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesCommonRuleSet",<br>    "override_action": "none",<br>    "priority": 10,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesAmazonIpReputationList",<br>    "override_action": "none",<br>    "priority": 20,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesKnownBadInputsRuleSet",<br>    "override_action": "none",<br>    "priority": 30,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesSQLiRuleSet",<br>    "override_action": "none",<br>    "priority": 40,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesLinuxRuleSet",<br>    "override_action": "none",<br>    "priority": 50,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesUnixRuleSet",<br>    "override_action": "none",<br>    "priority": 60,<br>    "vendor_name": "AWS"<br>  }<br>]</pre> | no |
-| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | The name of the metric to create, if we are enabling CloudWatch | `string` | `"FG_WEBACL_ALB_Entityx"` | no |
+| <a name="input_group_rules"></a> [group\_rules](#input\_group\_rules) | Add here rules for ip\_sets, if any | `any` | `[]` | no |
+| <a name="input_ip_rate_based_rules"></a> [ip\_rate\_based\_rules](#input\_ip\_rate\_based\_rules) | Add here rules for ip\_sets, if any | `any` | `[]` | no |
+| <a name="input_ip_rate_url_based_rules"></a> [ip\_rate\_url\_based\_rules](#input\_ip\_rate\_url\_based\_rules) | Add here rules for ip\_sets, if any | `any` | `[]` | no |
+| <a name="input_ip_sets_rules"></a> [ip\_sets\_rules](#input\_ip\_sets\_rules) | Add here rules for ip\_sets, if any | `any` | `[]` | no |
+| <a name="input_managed_rules"></a> [managed\_rules](#input\_managed\_rules) | List of Managed WAF rules. | <pre>list(object({<br>    name            = string<br>    priority        = number<br>    override_action = string<br>    vendor_name     = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "AWSManagedRulesCommonRuleSet",<br>    "override_action": "none",<br>    "priority": 10,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "name": "AWSManagedRulesAmazonIpReputationList",<br>    "override_action": "none",<br>    "priority": 20,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "name": "AWSManagedRulesKnownBadInputsRuleSet",<br>    "override_action": "none",<br>    "priority": 30,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "name": "AWSManagedRulesSQLiRuleSet",<br>    "override_action": "none",<br>    "priority": 40,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "name": "AWSManagedRulesLinuxRuleSet",<br>    "override_action": "none",<br>    "priority": 50,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "name": "AWSManagedRulesUnixRuleSet",<br>    "override_action": "none",<br>    "priority": 60,<br>    "vendor_name": "AWS"<br>  }<br>]</pre> | no |
+| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | The name of the metric to create, if we are enabling CloudWatch | `string` | `"FG_WEBACL_ALB"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the WEB ACL | `string` | n/a | yes |
+| <a name="input_storage_logs_arn"></a> [storage\_logs\_arn](#input\_storage\_logs\_arn) | ARN of the destination of the logs. It can be S3, CW or Kinesis | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Useful to diferentiate resources per env, team, function ... | `map(any)` | `{}` | no |
 
 ## Outputs

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -221,7 +221,7 @@ dynamic "rule" {
   visibility_config {
     cloudwatch_metrics_enabled = var.enable_cloudwatch
     sampled_requests_enabled   = var.enable_sampled_requests
-    metric_name                = var.metric_name
+    metric_name                = "${var.metric_name}_${var.name}"
   }
 
   tags = var.tags

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -83,7 +83,7 @@ resource "aws_wafv2_web_acl_association" "fg_waf_to_alb" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "fg_logging_waf" {
-  count = enable_logging ? 1 : 0
+  count = var.enable_logging ? 1 : 0
 
   log_destination_configs = var.storage_logs_arn
   resource_arn            = aws_wafv2_web_acl.fg_web_acl_alb.arn

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -85,6 +85,6 @@ resource "aws_wafv2_web_acl_association" "fg_waf_to_alb" {
 resource "aws_wafv2_web_acl_logging_configuration" "fg_logging_waf" {
   count = var.enable_logging ? 1 : 0
 
-  log_destination_configs = var.storage_logs_arn
+  log_destination_configs = [var.storage_logs_arn]
   resource_arn            = aws_wafv2_web_acl.fg_web_acl_alb.arn
 }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -76,7 +76,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
   tags = var.tags
 }
 
-resource "aws_wafv2_web_acl_association" "example" {
+resource "aws_wafv2_web_acl_association" "fg_waf_to_alb" {
   web_acl_arn  = aws_wafv2_web_acl.fg_web_acl_alb.arn
   resource_arn = var.alb_arn
 }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -68,14 +68,10 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
     content {
       name = rule.value.name
       priority = rule.value.priority
-      action {
-        rule.value.action
-      }
-      statement {
-        rule.value.statement
-      }
       visibility_config {
-        rule.value.visibility_config
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+        metric_name                = rule.value.metric_name
       }
     }
   }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -65,6 +65,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 
   dynamic "rule" {
     for_each = var.custom_rules
+    content {}
   }
 
   visibility_config {

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -65,7 +65,19 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 
   dynamic "rule" {
     for_each = var.custom_rules
-    content {}
+    content {
+      name = rule.value.name
+      priority = rule.value.priority
+      action {
+        rule.value.action
+      }
+      statement {
+        rule.value.statement
+      }
+      visibility_config {
+        rule.value.visibility_config
+      }
+    }
   }
 
   visibility_config {

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -71,7 +71,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
       visibility_config {
         cloudwatch_metrics_enabled = false
         sampled_requests_enabled   = false
-        metric_name                = rule.value.metric_name
+        metric_name                = rule.value.visibility_config_metric_name
       }
     }
   }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -57,10 +57,14 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 
       visibility_config {
         cloudwatch_metrics_enabled = true
-        metric_name                = rule.value.name
         sampled_requests_enabled   = true
+        metric_name                = rule.value.name
       }
     }
+  }
+
+  dynamic "rule" {
+    for_each = var.custom_rules
   }
 
   visibility_config {
@@ -70,4 +74,16 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
   }
 
   tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "example" {
+  web_acl_arn  = aws_wafv2_web_acl.fg_web_acl_alb.arn
+  resource_arn = var.alb_arn
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "fg_logging_waf" {
+  count = enable_logging ? 1 : 0
+
+  log_destination_configs = var.storage_logs_arn
+  resource_arn            = aws_wafv2_web_acl.fg_web_acl_alb.arn
 }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -46,10 +46,11 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
           name        = rule.value.name
           vendor_name = rule.value.vendor_name
 
-          dynamic "excluded_rule" {
-            for_each = rule.value.excluded_rules
+          dynamic "rule_action_override" {
+            for_each = rule.value.override_action
             content {
-              name = excluded_rule.value
+              name = rule.value.name
+              action_to_use = rule.value.override_action
             }
           }
         }
@@ -201,10 +202,11 @@ dynamic "rule" {
         rule_group_reference_statement {
           arn = rule.value.group_rule_arn
 
-          dynamic "excluded_rule" {
-            for_each = rule.value.excluded_rules
+          dynamic "rule_action_override" {
+            for_each = rule.value.override_action
             content {
-              name = excluded_rule.value
+              name = rule.value.name
+              action_to_use = rule.value.override_action
             }
           }
         }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -1,0 +1,73 @@
+resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
+  name        = var.name
+  description = var.description
+  scope       = "REGIONAL"
+
+  default_action {
+    dynamic "allow" {
+      for_each = var.default_action == "allow" ? [1] : []
+      content {}
+    }
+    dynamic "block" {
+      for_each = var.default_action == "block" ? [1] : []
+      content {}
+    }
+  }
+
+  dynamic "custom_response_body" {
+    for_each = var.custom_responses
+    content {
+      key          = custom_responses.value.key
+      content      = custom_responses.value.content
+      content_type = custom_responses.value.content_type
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.managed_rules
+    content {
+      name     = rule.value.name
+      priority = rule.value.priority
+
+      override_action {
+        dynamic "none" {
+          for_each = rule.value.override_action == "none" ? [1] : []
+          content {}
+        }
+
+        dynamic "count" {
+          for_each = rule.value.override_action == "count" ? [1] : []
+          content {}
+        }
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = rule.value.name
+          vendor_name = rule.value.vendor_name
+
+          dynamic "excluded_rule" {
+            for_each = rule.value.excluded_rules
+            content {
+              name = excluded_rule.value
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = rule.value.name
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = var.enable_cloudwatch
+    sampled_requests_enabled   = var.enable_sampled_requests
+    metric_name                = var.metric_name
+  }
+
+  tags = var.tags
+}

--- a/aws/waf-acl-alb/outputs.tf
+++ b/aws/waf-acl-alb/outputs.tf
@@ -1,0 +1,15 @@
+output "web_acl_id" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.id, "")
+}
+
+output "web_acl_arn" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.arn, "")
+}
+
+output "web_acl_capacity" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.capacity, "")
+}
+
+output "web_acl_tags" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.tags_all, "")
+}

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -1,0 +1,100 @@
+variable "name" {
+  description = "Name of the WEB ACL"
+  type        = string
+}
+
+variable "description" {
+  description = "Something meaningful to describe this ACL"
+  type        = string
+}
+
+variable "default_action" {
+  description = "Action to apply if no rules match"
+  type        = string
+  default     = "allow"
+}
+
+variable "alb_arn" {
+  description = "ARN of the Application LB to associate with"
+  type        = string
+}
+
+variable "enable_logging" {
+  description = "Log all traffic through the ACL"
+  type        = bool
+  default     = false
+}
+
+variable "enable_cloudwatch" {
+  description = "Enable metrics for the ACL"
+  type        = bool
+  default     = false
+}
+
+variable "enable_sampled_requests" {
+  description = "Enable sampled requests for the ACL"
+  type        = bool
+  default     = false
+}
+
+variable "metric_name" {
+  description = "The name of the metric to create, if we are enabling CloudWatch"
+  type        = string
+  default     = ""
+}
+
+variable "managed_rules" {
+  type = list(object({
+    name            = string
+    priority        = number
+    override_action = string
+    excluded_rules  = list(string)
+    vendor_name     = string
+  }))
+  description = "List of Managed WAF rules."
+  default = [
+    {
+      name            = "AWSManagedRulesCommonRuleSet",
+      priority        = 10
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesAmazonIpReputationList",
+      priority        = 20
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesKnownBadInputsRuleSet",
+      priority        = 30
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesSQLiRuleSet",
+      priority        = 40
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesLinuxRuleSet",
+      priority        = 50
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesUnixRuleSet",
+      priority        = 60
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    }
+  ]
+}
+

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -44,7 +44,7 @@ variable "metric_name" {
 }
 
 variable "tags" {
-  descriotion = "Useful to diferentiate resources per env, team, function ..."
+  description = "Useful to diferentiate resources per env, team, function ..."
   type        = map(any)
   default     = {}
 }

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -67,7 +67,7 @@ variable "custom_responses" {
 
 variable "custom_rules" {
   description = "Add here all the rules as a list of maps"
-  type        = list
+  type        = any
   default     = []
 }
 

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -46,7 +46,7 @@ variable "enable_sampled_requests" {
 variable "metric_name" {
   description = "The name of the metric to create, if we are enabling CloudWatch"
   type        = string
-  default     = "FG_WEBACL_ALB_Entityx"
+  default     = "FG_WEBACL_ALB"
 }
 
 variable "tags" {

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -43,6 +43,12 @@ variable "metric_name" {
   default     = ""
 }
 
+variable "tags" {
+  descriotion = "Useful to diferentiate resources per env, team, function ..."
+  type        = map(any)
+  default     = {}
+}
+
 variable "managed_rules" {
   type = list(object({
     name            = string

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -49,6 +49,16 @@ variable "tags" {
   default     = {}
 }
 
+variable "custom_responses" {
+  description = "The custom response behaviour for the default web ACL action"
+  type = list(object({
+    key          = string
+    content      = string
+    content_type = string
+  }))
+  default = []
+}
+
 variable "managed_rules" {
   type = list(object({
     name            = string

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -67,7 +67,7 @@ variable "custom_responses" {
 
 variable "custom_rules" {
   description = "Add here all the rules as a list of maps"
-  type        = list(string)
+  type        = list
   default     = []
 }
 

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -40,7 +40,7 @@ variable "enable_sampled_requests" {
 variable "metric_name" {
   description = "The name of the metric to create, if we are enabling CloudWatch"
   type        = string
-  default     = ""
+  default     = "FG_WEBACL_ALB_Entityx"
 }
 
 variable "tags" {

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -25,6 +25,12 @@ variable "enable_logging" {
   default     = false
 }
 
+variable "storage_logs_arn" {
+  description = "ARN of the destination of the logs. It can be S3, CW or Kinesis"
+  type        = string
+  default     = ""
+}
+
 variable "enable_cloudwatch" {
   description = "Enable metrics for the ACL"
   type        = bool

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -94,7 +94,6 @@ variable "managed_rules" {
     name            = string
     priority        = number
     override_action = string
-    excluded_rules  = list(string)
     vendor_name     = string
   }))
   description = "List of Managed WAF rules."
@@ -103,42 +102,36 @@ variable "managed_rules" {
       name            = "AWSManagedRulesCommonRuleSet",
       priority        = 10
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesAmazonIpReputationList",
       priority        = 20
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesKnownBadInputsRuleSet",
       priority        = 30
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesSQLiRuleSet",
       priority        = 40
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesLinuxRuleSet",
       priority        = 50
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesUnixRuleSet",
       priority        = 60
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     }
   ]

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -65,8 +65,26 @@ variable "custom_responses" {
   default = []
 }
 
-variable "custom_rules" {
-  description = "Add here all the rules as a list of maps"
+variable "ip_sets_rules" {
+  description = "Add here rules for ip_sets, if any"
+  type        = any
+  default     = []
+}
+
+variable "ip_rate_based_rules" {
+  description = "Add here rules for ip_sets, if any"
+  type        = any
+  default     = []
+}
+
+variable "ip_rate_url_based_rules" {
+  description = "Add here rules for ip_sets, if any"
+  type        = any
+  default     = []
+}
+
+variable "group_rules" {
+  description = "Add here rules for ip_sets, if any"
   type        = any
   default     = []
 }

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -28,13 +28,13 @@ variable "enable_logging" {
 variable "enable_cloudwatch" {
   description = "Enable metrics for the ACL"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_sampled_requests" {
   description = "Enable sampled requests for the ACL"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "metric_name" {
@@ -57,6 +57,12 @@ variable "custom_responses" {
     content_type = string
   }))
   default = []
+}
+
+variable "custom_rules" {
+  description = "Add here all the rules as a list of maps"
+  type        = list(string)
+  default     = []
 }
 
 variable "managed_rules" {

--- a/aws/waf-acl-alb/versions.tf
+++ b/aws/waf-acl-alb/versions.tf
@@ -5,6 +5,6 @@ terraform {
       version = "4.58.0"
     }
   }
-  required_version = "~> 4.47.1"
+  required_version = "~> 1.4.0"
 }
 

--- a/aws/waf-acl-alb/versions.tf
+++ b/aws/waf-acl-alb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.58.0"
+    }
+  }
+  required_version = "~> 4.47.1"
+}
+


### PR DESCRIPTION
Requires:
- Name for the Web ACL
- Description for the Web ACL
- ARN of an existing ALB

Defaults:
- default action: allow
- Logs are disabled by default: it will require the arn of an s3,Cloudwatch LG, Kinesis when enabled
- Cloudwatch is enabled by default
- Sampled requests are enabled by default
- It creates a Metric with suffix: FG_WEBACL_ALB

Creates:
- Web ACL 
     - Accepts a list of AWS Managed rules, defaults to the full list of managed rules
     - Accepts a list of rules of the following types:
          - ip sets
          - ip rate
          - ip rate URLs
          - Group rules
- Association with an existing ALB
- Logging configuration