### PR TITLE
fix: alb access logs

### DIFF
--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
       "s3:PutObject",
     ]
     resources = [
-      aws_s3_bucket.fg_alb_access_logs[0].arn
+      aws_alb.application.arn
     ]
   }
 }

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -42,8 +42,9 @@ resource "aws_lb" "application" {
 ## Optional S3 Bucket Resources for Access Logs
 
 resource "aws_s3_bucket" "fg_alb_access_logs" {
-  count  = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
-  bucket = "fg-alb-access-logs"
+  count         = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+  bucket        = "fg-alb-access-logs"
+  force_destroy = var.force_destroy_alb_access_logs
 }
 
 resource "aws_s3_bucket_acl" "fg_alb_access_logs" {

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -61,17 +61,21 @@ resource "aws_s3_bucket_policy" "fg_alb_access_logs" {
 
 data "aws_elb_service_account" "main" {}
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
+  version = "2012-10-17"
   statement {
     principals {
       type        = "AWS"
       identifiers = [data.aws_elb_service_account.main.arn]
     }
+    effect = "Allow"
     actions = [
       "s3:PutObject",
     ]
     resources = [
-      aws_lb.application.arn
+      "arn:aws:s3:::fg-alb-access-logs/fg-alb/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
     ]
   }
 }

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
       "s3:PutObject",
     ]
     resources = [
-      aws_alb.application.arn
+      aws_lb.application.arn
     ]
   }
 }

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -47,6 +47,68 @@ resource "aws_s3_bucket" "fg_alb_access_logs" {
   bucket = "fg-alb-access-logs"
 }
 
+resource "aws_s3_bucket_acl" "fg_alb_access_logs" {
+  count = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+
+  bucket = aws_s3_bucket.fg_alb_access_logs[0].id
+  acl    = "private"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_elb_service_account" "main" {}
+
+resource "aws_s3_bucket_policy" "lb-bucket-policy" {
+  count = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+
+  bucket = aws_s3_bucket.fg_alb_access_logs[0].id
+
+  policy = <<POLICY
+{
+    "Id": "Policy",
+    "Version": "2012-10-17",
+    "Statement": [{
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "${data.aws_elb_service_account.main.arn}"
+                ]
+            },
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": "${aws_s3_bucket.fg_alb_access_logs[0].arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "delivery.logs.amazonaws.com"
+            },
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": "${aws_s3_bucket.fg_alb_access_logs[0].arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "delivery.logs.amazonaws.com"
+            },
+            "Action": [
+                "s3:GetBucketAcl"
+            ],
+            "Resource": "${aws_s3_bucket.fg_alb_access_logs[0].arn}"
+        }
+    ]
+}
+POLICY
+}
+
 ## Default Security Group
 resource "aws_security_group" "default_fg_alb" {
   name        = var.security_group_name

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -34,7 +34,7 @@ resource "aws_lb" "application" {
   dynamic "access_logs" {
     for_each = var.enable_access_logging ? { enabled = true } : {}
     content {
-      bucket  = var.s3_bucket_id != "" ? var.s3_bucket_id : var.enable_access_logging ? aws_s3_bucket.fg_alb_access_logs[0].id : ""
+      bucket  = var.s3_bucket_id != "" ? var.s3_bucket_id : aws_s3_bucket.fg_alb_access_logs[0].id
       enabled = var.enable_access_logging
     }
 

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -31,9 +31,13 @@ resource "aws_lb" "application" {
   security_groups    = concat([aws_security_group.default_fg_alb.id], var.alb_security_group_ids)
   subnets            = var.alb_type_internal ? data.aws_subnets.private.ids : data.aws_subnets.public.ids
 
-  access_logs {
-    bucket  = var.s3_bucket != "" ? var.s3_bucket.id : var.enable_access_logging ? aws_s3_bucket.fg_alb_access_logs[0].id : ""
-    enabled = var.enable_access_logging
+  dynamic "access_logs" {
+    for_each = var.enable_access_logging ? { enabled = true } : {}
+    content {
+      bucket  = var.s3_bucket != "" ? var.s3_bucket.id : var.enable_access_logging ? aws_s3_bucket.fg_alb_access_logs[0].id : ""
+      enabled = var.enable_access_logging
+    }
+
   }
 
   tags = var.tags
@@ -79,7 +83,6 @@ data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
     ]
   }
 }
-
 
 ## Default Security Group
 resource "aws_security_group" "default_fg_alb" {

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
       "s3:PutObject",
     ]
     resources = [
-      aws_s3_bucket.fg_alb_access_logs.arn
+      aws_s3_bucket.fg_alb_access_logs[0].arn
     ]
   }
 }

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -47,7 +47,7 @@ resource "aws_lb" "application" {
 
 resource "aws_s3_bucket" "fg_alb_access_logs" {
   count         = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
-  bucket        = "fg-alb-access-logs"
+  bucket        = "${var.alb_name}-access-logs"
   force_destroy = var.force_destroy_alb_access_logs
 }
 

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -33,7 +33,6 @@ resource "aws_lb" "application" {
 
   access_logs {
     bucket  = var.s3_bucket != "" ? var.s3_bucket.id : var.enable_access_logging ? aws_s3_bucket.fg_alb_access_logs[0].id : ""
-    prefix  = "fg-alb"
     enabled = var.enable_access_logging
   }
 
@@ -75,7 +74,7 @@ data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
       "s3:PutObject",
     ]
     resources = [
-      "arn:aws:s3:::fg-alb-access-logs/fg-alb/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+      "${aws_s3_bucket.fg_alb_access_logs.arn}/*"
     ]
   }
 }

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
       "s3:PutObject",
     ]
     resources = [
-      "${aws_s3_bucket.fg_alb_access_logs.arn}/*"
+      "${aws_s3_bucket.fg_alb_access_logs[0].arn}/*"
     ]
   }
 }

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -34,7 +34,7 @@ resource "aws_lb" "application" {
   dynamic "access_logs" {
     for_each = var.enable_access_logging ? { enabled = true } : {}
     content {
-      bucket  = var.s3_bucket != "" ? var.s3_bucket.id : var.enable_access_logging ? aws_s3_bucket.fg_alb_access_logs[0].id : ""
+      bucket  = var.s3_bucket_id != "" ? var.s3_bucket_id : var.enable_access_logging ? aws_s3_bucket.fg_alb_access_logs[0].id : ""
       enabled = var.enable_access_logging
     }
 
@@ -46,19 +46,19 @@ resource "aws_lb" "application" {
 ## Optional S3 Bucket Resources for Access Logs
 
 resource "aws_s3_bucket" "fg_alb_access_logs" {
-  count         = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+  count         = (var.enable_access_logging && (var.s3_bucket_id == "")) ? 1 : 0
   bucket        = "${var.alb_name}-access-logs"
   force_destroy = var.force_destroy_alb_access_logs
 }
 
 resource "aws_s3_bucket_acl" "fg_alb_access_logs" {
-  count  = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+  count  = (var.enable_access_logging && (var.s3_bucket_id == "")) ? 1 : 0
   bucket = aws_s3_bucket.fg_alb_access_logs[0].id
   acl    = "private"
 }
 
 resource "aws_s3_bucket_policy" "fg_alb_access_logs" {
-  count  = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+  count  = (var.enable_access_logging && (var.s3_bucket_id == "")) ? 1 : 0
   bucket = aws_s3_bucket.fg_alb_access_logs[0].id
   policy = data.aws_iam_policy_document.allow_alb_write_to_bucket[0].json
 }
@@ -68,7 +68,7 @@ data "aws_elb_service_account" "main" {}
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
-  count = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+  count = (var.enable_access_logging && (var.s3_bucket_id == "")) ? 1 : 0
 
   version = "2012-10-17"
   statement {

--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -60,7 +60,7 @@ resource "aws_s3_bucket_acl" "fg_alb_access_logs" {
 resource "aws_s3_bucket_policy" "fg_alb_access_logs" {
   count  = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
   bucket = aws_s3_bucket.fg_alb_access_logs[0].id
-  policy = data.aws_iam_policy_document.allow_alb_write_to_bucket.json
+  policy = data.aws_iam_policy_document.allow_alb_write_to_bucket[0].json
 }
 
 data "aws_elb_service_account" "main" {}
@@ -68,6 +68,8 @@ data "aws_elb_service_account" "main" {}
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "allow_alb_write_to_bucket" {
+  count = (var.enable_access_logging && (var.s3_bucket == "")) ? 1 : 0
+
   version = "2012-10-17"
   statement {
     principals {

--- a/aws/app-lb/outputs.tf
+++ b/aws/app-lb/outputs.tf
@@ -30,6 +30,38 @@ output "alb_zone_id" {
   value       = try(aws_lb.application.zone_id, {})
 }
 
+## ALB Access Logs
+
+output "access_logs_bucket_name" {
+  description = "Name of the s3 bucket used to store access logs."
+  value       = try(aws_s3_bucket.fg_alb_access_logs[0].id, "")
+}
+
+output "access_logs_bucket_arn" {
+  description = "ARN of the s3 bucket used to store access logs."
+  value       = try(aws_s3_bucket.fg_alb_access_logs[0].arn, "")
+}
+
+output "access_logs_bucket_domain_name" {
+  description = "Domain name of the s3 bucket used to store access logs."
+  value       = try(aws_s3_bucket.fg_alb_access_logs[0].bucket_domain_name, "")
+}
+
+output "access_logs_bucket_regional_domain_name" {
+  description = "Regional domain name of the s3 bucket used to store access logs."
+  value       = try(aws_s3_bucket.fg_alb_access_logs[0].bucket_regional_domain_name, "")
+}
+
+output "access_logs_bucket_region" {
+  description = "Region of the s3 bucket used to store access logs."
+  value       = try(aws_s3_bucket.fg_alb_access_logs[0].region, "")
+}
+
+output "access_logs_bucket_tags" {
+  description = "Map with all tags for S3 buckets used to store ALB logs."
+  value       = try(aws_s3_bucket.fg_alb_access_logs[0].tags_all, {})
+}
+
 ## Default Security Group
 
 output "default_alb_security_group_id" {

--- a/aws/app-lb/variables.tf
+++ b/aws/app-lb/variables.tf
@@ -28,6 +28,12 @@ variable "s3_bucket" {
   default     = ""
 }
 
+variable "force_destroy_alb_access_logs" {
+  type        = bool
+  description = "Boolean to specify whether to force destroy access_logs when s3 bucket is destroyed - when false, s3 bucket cannot be destroyed without error."
+  default     = true
+}
+
 ## Health Check
 
 variable "health_check" {

--- a/aws/app-lb/variables.tf
+++ b/aws/app-lb/variables.tf
@@ -22,9 +22,9 @@ variable "enable_access_logging" {
   description = "Boolean to specify whether to store access logs for the ALB."
 }
 
-variable "s3_bucket" {
+variable "s3_bucket_id" {
   type        = string
-  description = "S3 bucket to store the logs in. If none is passed in by user, a new S3 bucket will be created."
+  description = "Name/ID of the S3 bucket to store the logs in. If none is passed in by user, a new S3 bucket will be created."
   default     = ""
 }
 


### PR DESCRIPTION
PR to fix access logging for the Application Load Balancer. 

Makes ALB access logs configurable, with an "enable_access_logging" boolean and an optional s3 bucket variable. If this latter variable is not given a value, but access logging is enabled, the module will create an s3 bucket with the appropriate policy attached.

Will apply the changes in this PR to the NLB module also.