### PR TITLE
feat: separate lint into distinct azure/aws workflows

### DIFF
--- a/.github/workflows/tflint-aws.yml
+++ b/.github/workflows/tflint-aws.yml
@@ -1,0 +1,40 @@
+name: Lint AWS
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "aws/**"
+      - .github/workflows/tflint.yml
+
+jobs:
+  tflint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout source code
+
+      - uses: actions/cache@v3
+        name: Cache plugin dir
+        with:
+          path: ~/.tflint.d/plugins
+          key: ubuntu-latest-tflint-${{ hashFiles('.tflint.hcl') }}
+
+      - uses: terraform-linters/setup-tflint@v3
+        name: Setup TFLint
+        with:
+          tflint_version: v0.44.1
+
+      - name: Show version
+        run: tflint --version
+
+      - name: Init TFLint
+        run: tflint --init
+        env:
+          # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Run TFLint
+        run: tflint -f compact --recursive
+        working-directory: ./aws

--- a/.github/workflows/tflint-azure.yml
+++ b/.github/workflows/tflint-azure.yml
@@ -1,20 +1,15 @@
-name: Lint
+name: Lint Azure
 on:
   pull_request:
     branches:
       - master
     paths:
       - "azure/**"
-      - "aws/**"
       - .github/workflows/tflint.yml
 
 jobs:
   tflint:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        dir: ["aws", "azure"]
 
     steps:
       - uses: actions/checkout@v3
@@ -42,4 +37,4 @@ jobs:
 
       - name: Run TFLint
         run: tflint -f compact --recursive
-        working-directory: ${{matrix.dir}}
+        working-directory: ./azure


### PR DESCRIPTION
Separates out lint workflows, to ensure they only run when changes are made to the relevant directories.