### PR TITLE
fix: AWS - Add target type var

### DIFF
--- a/aws/app-lb/main.tf
+++ b/aws/app-lb/main.tf
@@ -111,10 +111,11 @@ resource "aws_vpc_security_group_egress_rule" "http" {
 
 ## Default Target Group
 resource "aws_lb_target_group" "default" {
-  name     = "${var.alb_name}-tg"
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = var.vpc_id
+  name        = "${var.alb_name}-tg"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = var.target_type
 
   health_check {
     timeout             = var.health_check.timeout

--- a/aws/app-lb/variables.tf
+++ b/aws/app-lb/variables.tf
@@ -34,6 +34,14 @@ variable "force_destroy_alb_access_logs" {
   default     = true
 }
 
+## Target Group
+
+variable "target_type" {
+  type        = string
+  description = "Type of ALB's default target group's targets."
+  default     = "instance"
+}
+
 ## Health Check
 
 variable "health_check" {


### PR DESCRIPTION
Adds variable to configure ALB target type if needed (default value "instance).