### PR TITLE
Fix: aws sg rules new resource

### DIFF
--- a/aws/app-lb/README.md
+++ b/aws/app-lb/README.md
@@ -1,13 +1,16 @@
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.58.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.58.0 |
 
 ## Modules
 
@@ -17,22 +20,26 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_acm_certificate.fg_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
-| [aws_acm_certificate_validation.fg_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
-| [aws_lb.application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
-| [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_s3_bucket.fg_alb_access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_security_group.default_fg_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_vpc_security_group_egress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.internet_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.internet_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
-| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_acm_certificate.fg_alb](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/acm_certificate) | resource |
+| [aws_acm_certificate_validation.fg_alb](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/acm_certificate_validation) | resource |
+| [aws_lb.application](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/lb) | resource |
+| [aws_lb_listener.http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.default](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/lb_target_group) | resource |
+| [aws_s3_bucket.fg_alb_access_logs](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.fg_alb_access_logs](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_policy.fg_alb_access_logs](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_security_group.default_fg_alb](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.internet_http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.internet_https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.allow_alb_write_to_bucket](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/subnets) | data source |
+| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/data-sources/subnets) | data source |
 
 ## Inputs
 
@@ -48,19 +55,26 @@ No modules.
 | <a name="input_enable_access_logging"></a> [enable\_access\_logging](#input\_enable\_access\_logging) | Boolean to specify whether to store access logs for the ALB. | `bool` | n/a | yes |
 | <a name="input_enable_internal_alb_tls"></a> [enable\_internal\_alb\_tls](#input\_enable\_internal\_alb\_tls) | Boolean to specify whether to enable TLS for the Internal Application Load Balancer. (External ALB has TLS enabled by default.) | `bool` | `false` | no |
 | <a name="input_external_internet_ingress_ip_address"></a> [external\_internet\_ingress\_ip\_address](#input\_external\_internet\_ingress\_ip\_address) | IP address to allow external ALB HTTPS access from. | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_force_destroy_alb_access_logs"></a> [force\_destroy\_alb\_access\_logs](#input\_force\_destroy\_alb\_access\_logs) | Boolean to specify whether to force destroy access\_logs when s3 bucket is destroyed - when false, s3 bucket cannot be destroyed without error. | `bool` | `true` | no |
 | <a name="input_health_check"></a> [health\_check](#input\_health\_check) | Map describing Health Check settings - including endpoint (default /) and port (default 80). | `map(string)` | <pre>{<br>  "healthy_threshold": "3",<br>  "interval": "20",<br>  "matcher": "200",<br>  "path": "/",<br>  "port": "80",<br>  "protocol": "HTTP",<br>  "timeout": "10",<br>  "unhealthy_threshold": "2"<br>}</pre> | no |
 | <a name="input_internal_ingress_ip_address"></a> [internal\_ingress\_ip\_address](#input\_internal\_ingress\_ip\_address) | IP address to allow internal ALB access from. | `string` | `"10.0.0.0/16"` | no |
-| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | S3 bucket to store the logs in. If none is passed in by user, a new S3 bucket will be created. | `string` | `""` | no |
+| <a name="input_s3_bucket_id"></a> [s3\_bucket\_id](#input\_s3\_bucket\_id) | Name/ID of the S3 bucket to store the logs in. If none is passed in by user, a new S3 bucket will be created. | `string` | `""` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of aws security group. | `string` | n/a | yes |
 | <a name="input_ssl_cert"></a> [ssl\_cert](#input\_ssl\_cert) | Optional ARN of custom SSL server certificate. If this field is not specified module will create an Amazon-issued ACM certificate. | `string` | `null` | no |
 | <a name="input_ssl_security_policy"></a> [ssl\_security\_policy](#input\_ssl\_security\_policy) | Name of SSL Policy for internal HTTPS listener. | `string` | `"ELBSecurityPolicy-2016-08"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id for use in target group, security group and to retrieve subnets. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_access_logs_bucket_arn"></a> [access\_logs\_bucket\_arn](#output\_access\_logs\_bucket\_arn) | ARN of the s3 bucket used to store access logs. |
+| <a name="output_access_logs_bucket_domain_name"></a> [access\_logs\_bucket\_domain\_name](#output\_access\_logs\_bucket\_domain\_name) | Domain name of the s3 bucket used to store access logs. |
+| <a name="output_access_logs_bucket_name"></a> [access\_logs\_bucket\_name](#output\_access\_logs\_bucket\_name) | Name of the s3 bucket used to store access logs. |
+| <a name="output_access_logs_bucket_region"></a> [access\_logs\_bucket\_region](#output\_access\_logs\_bucket\_region) | Region of the s3 bucket used to store access logs. |
+| <a name="output_access_logs_bucket_regional_domain_name"></a> [access\_logs\_bucket\_regional\_domain\_name](#output\_access\_logs\_bucket\_regional\_domain\_name) | Regional domain name of the s3 bucket used to store access logs. |
+| <a name="output_access_logs_bucket_tags"></a> [access\_logs\_bucket\_tags](#output\_access\_logs\_bucket\_tags) | Map with all tags for S3 buckets used to store ALB logs. |
 | <a name="output_alb_arn"></a> [alb\_arn](#output\_alb\_arn) | The Amazon Resource Name (ARN) or ID of the Application Load Balancer. |
 | <a name="output_alb_arn_suffix"></a> [alb\_arn\_suffix](#output\_alb\_arn\_suffix) | The ALB's ARN suffix for use with CloudWatch Metrics. |
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | The ALB's DNS name. |

--- a/aws/ec2-instance/README.md
+++ b/aws/ec2-instance/README.md
@@ -3,6 +3,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.58.0 |
 
 ## Providers
@@ -47,7 +48,7 @@ No modules.
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description of aws security group. | `string` | n/a | yes |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name of aws security group. | `string` | n/a | yes |
 | <a name="input_ssh_ingress_ip_address"></a> [ssh\_ingress\_ip\_address](#input\_ssh\_ingress\_ip\_address) | IP address to allow SSH access from | `string` | `"0.0.0.0/0"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | `{}` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data to provide as a bash script when launching the instance. Default value null. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id for use in security group. | `string` | n/a | yes |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC | `string` | `"test"` | no |

--- a/aws/vpc/README.md
+++ b/aws/vpc/README.md
@@ -3,6 +3,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.58.0 |
 
 ## Providers
@@ -27,16 +28,16 @@ No modules.
 | [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/route_table_association) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
 | [aws_security_group.public](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group) | resource |
-| [aws_security_group_rule.egress_local](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_local](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.public_egress](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.public_http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.public_https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/security_group_rule) | resource |
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/subnet) | resource |
 | [aws_vpc.fg_vpc](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc) | resource |
 | [aws_vpc_dhcp_options.default](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_dhcp_options) | resource |
 | [aws_vpc_dhcp_options_association.default](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_dhcp_options_association) | resource |
+| [aws_vpc_security_group_egress_rule.egress_local](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.public_egress](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.ingress_local](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.public_http](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.public_https](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 
 ## Inputs
 

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -131,6 +131,7 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_local" {
   from_port         = "0"
   to_port           = "0"
   ip_protocol       = "-1"
+  cidr_ipv4         = var.vpc_cidr
   security_group_id = aws_security_group.default.id
 }
 
@@ -138,6 +139,7 @@ resource "aws_vpc_security_group_egress_rule" "egress_local" {
   from_port         = "0"
   to_port           = "0"
   ip_protocol       = "-1"
+  cidr_ipv4         = var.vpc_cidr
   security_group_id = aws_security_group.default.id
 }
 

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -165,8 +165,6 @@ resource "aws_vpc_security_group_ingress_rule" "public_https" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "public_egress" {
-  from_port         = 0
-  to_port           = 0
   ip_protocol       = "-1"
   cidr_ipv4         = "0.0.0.0/0"
   security_group_id = aws_security_group.public.id

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -127,8 +127,7 @@ resource "aws_security_group" "default" {
   tags = var.tags
 }
 
-resource "aws_security_group_rule" "ingress_local" {
-  type              = "ingress"
+resource "aws_vpc_security_group_ingress_rule" "ingress_local" {
   from_port         = "0"
   to_port           = "0"
   protocol          = "-1"
@@ -136,8 +135,7 @@ resource "aws_security_group_rule" "ingress_local" {
   security_group_id = aws_security_group.default.id
 }
 
-resource "aws_security_group_rule" "egress_local" {
-  type              = "egress"
+resource "aws_vpc_security_group_egress_rule" "egress_local" {
   from_port         = "0"
   to_port           = "0"
   protocol          = "-1"
@@ -154,8 +152,7 @@ resource "aws_security_group" "public" {
   tags = var.tags
 }
 
-resource "aws_security_group_rule" "public_http" {
-  type              = "ingress"
+resource "aws_vpc_security_group_ingress_rule" "public_http" {
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
@@ -163,8 +160,7 @@ resource "aws_security_group_rule" "public_http" {
   security_group_id = aws_security_group.public.id
 }
 
-resource "aws_security_group_rule" "public_https" {
-  type              = "ingress"
+resource "aws_vpc_security_group_ingress_rule" "public_https" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
@@ -172,8 +168,7 @@ resource "aws_security_group_rule" "public_https" {
   security_group_id = aws_security_group.public.id
 }
 
-resource "aws_security_group_rule" "public_egress" {
-  type              = "egress"
+resource "aws_vpc_security_group_egress_rule" "public_egress" {
   from_port         = 0
   to_port           = 0
   protocol          = "-1"

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -128,16 +128,12 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "ingress_local" {
-  from_port         = "0"
-  to_port           = "0"
   ip_protocol       = "-1"
   cidr_ipv4         = var.vpc_cidr
   security_group_id = aws_security_group.default.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "egress_local" {
-  from_port         = "0"
-  to_port           = "0"
   ip_protocol       = "-1"
   cidr_ipv4         = var.vpc_cidr
   security_group_id = aws_security_group.default.id

--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -130,16 +130,14 @@ resource "aws_security_group" "default" {
 resource "aws_vpc_security_group_ingress_rule" "ingress_local" {
   from_port         = "0"
   to_port           = "0"
-  protocol          = "-1"
-  self              = true
+  ip_protocol       = "-1"
   security_group_id = aws_security_group.default.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "egress_local" {
   from_port         = "0"
   to_port           = "0"
-  protocol          = "-1"
-  self              = true
+  ip_protocol       = "-1"
   security_group_id = aws_security_group.default.id
 }
 
@@ -155,23 +153,23 @@ resource "aws_security_group" "public" {
 resource "aws_vpc_security_group_ingress_rule" "public_http" {
   from_port         = 80
   to_port           = 80
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
   security_group_id = aws_security_group.public.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "public_https" {
   from_port         = 443
   to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
   security_group_id = aws_security_group.public.id
 }
 
 resource "aws_vpc_security_group_egress_rule" "public_egress" {
   from_port         = 0
   to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
   security_group_id = aws_security_group.public.id
 }


### PR DESCRIPTION
Updating the code to newer resources to create Security Group rules
- Default security group:
     all ports
     all protocols
     within the VPC
- Public Security group:
     HTTP, HTTPs
     from anywhere
