### PR TITLE
Feature: AWS - waf acl alb

### DIFF
--- a/aws/waf-acl-alb/README.md
+++ b/aws/waf-acl-alb/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_wafv2_web_acl.fg_web_acl_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
+| [aws_wafv2_web_acl_association.fg_waf_to_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_logging_configuration.fg_logging_waf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alb_arn"></a> [alb\_arn](#input\_alb\_arn) | ARN of the Application LB to associate with | `string` | n/a | yes |
+| <a name="input_custom_responses"></a> [custom\_responses](#input\_custom\_responses) | The custom response behaviour for the default web ACL action | <pre>list(object({<br>    key          = string<br>    content      = string<br>    content_type = string<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_rules"></a> [custom\_rules](#input\_custom\_rules) | Add here all the rules as a list of maps | `list(string)` | `[]` | no |
+| <a name="input_default_action"></a> [default\_action](#input\_default\_action) | Action to apply if no rules match | `string` | `"allow"` | no |
+| <a name="input_description"></a> [description](#input\_description) | Something meaningful to describe this ACL | `string` | n/a | yes |
+| <a name="input_enable_cloudwatch"></a> [enable\_cloudwatch](#input\_enable\_cloudwatch) | Enable metrics for the ACL | `bool` | `true` | no |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Log all traffic through the ACL | `bool` | `false` | no |
+| <a name="input_enable_sampled_requests"></a> [enable\_sampled\_requests](#input\_enable\_sampled\_requests) | Enable sampled requests for the ACL | `bool` | `true` | no |
+| <a name="input_managed_rules"></a> [managed\_rules](#input\_managed\_rules) | List of Managed WAF rules. | <pre>list(object({<br>    name            = string<br>    priority        = number<br>    override_action = string<br>    excluded_rules  = list(string)<br>    vendor_name     = string<br>  }))</pre> | <pre>[<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesCommonRuleSet",<br>    "override_action": "none",<br>    "priority": 10,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesAmazonIpReputationList",<br>    "override_action": "none",<br>    "priority": 20,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesKnownBadInputsRuleSet",<br>    "override_action": "none",<br>    "priority": 30,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesSQLiRuleSet",<br>    "override_action": "none",<br>    "priority": 40,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesLinuxRuleSet",<br>    "override_action": "none",<br>    "priority": 50,<br>    "vendor_name": "AWS"<br>  },<br>  {<br>    "excluded_rules": [],<br>    "name": "AWSManagedRulesUnixRuleSet",<br>    "override_action": "none",<br>    "priority": 60,<br>    "vendor_name": "AWS"<br>  }<br>]</pre> | no |
+| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | The name of the metric to create, if we are enabling CloudWatch | `string` | `"FG_WEBACL_ALB_Entityx"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the WEB ACL | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Useful to diferentiate resources per env, team, function ... | `map(any)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_web_acl_arn"></a> [web\_acl\_arn](#output\_web\_acl\_arn) | n/a |
+| <a name="output_web_acl_capacity"></a> [web\_acl\_capacity](#output\_web\_acl\_capacity) | n/a |
+| <a name="output_web_acl_id"></a> [web\_acl\_id](#output\_web\_acl\_id) | n/a |
+| <a name="output_web_acl_tags"></a> [web\_acl\_tags](#output\_web\_acl\_tags) | n/a |
+<!-- END_TF_DOCS -->

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -221,7 +221,7 @@ dynamic "rule" {
   visibility_config {
     cloudwatch_metrics_enabled = var.enable_cloudwatch
     sampled_requests_enabled   = var.enable_sampled_requests
-    metric_name                = var.metric_name
+    metric_name                = "${var.metric_name}_${var.name}"
   }
 
   tags = var.tags

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -52,7 +52,11 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
               name = rule.value.name
               dynamic "action_to_use" {
                 for_each = rule.value.override_action == "none" ? [1] : []
-                  rule.value.override_action {}
+                  content {}
+              }
+              dynamic "action_to_use" {
+                for_each = rule.value.override_action == "count" ? [1] : []
+                  content {}
               }
             }
           }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -83,7 +83,7 @@ resource "aws_wafv2_web_acl_association" "fg_waf_to_alb" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "fg_logging_waf" {
-  count = enable_logging ? 1 : 0
+  count = var.enable_logging ? 1 : 0
 
   log_destination_configs = var.storage_logs_arn
   resource_arn            = aws_wafv2_web_acl.fg_web_acl_alb.arn

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -46,18 +46,16 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
           name        = rule.value.name
           vendor_name = rule.value.vendor_name
 
-          excluded_rule {}
-
-#          dynamic "rule_action_override" {
-#            for_each = rule.value.st_override_actions
-#            content {
-#              name = rule.value.name
-#              dynamic "action_to_use" {
-#                for_each = rule.value.st_override_actions
-#                content {}
-#              }
-#            }
-#          }
+          dynamic "rule_action_override" {
+            for_each = rule.value.st_override_actions
+            content {
+              name = rule.value.name
+              dynamic "action_to_use" {
+                for_each = rule.value.st_override_actions
+                content {}
+              }
+            }
+          }
         }
       }
 
@@ -207,16 +205,23 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
         rule_group_reference_statement {
           arn = rule.value.group_rule_arn
 
-          dynamic "rule_action_override" {
-            for_each = rule.value.st_override_actions
+          dynamic "excluded_rule" {
+            for_each = rule.value.excluded_rules
             content {
-              name = rule.value.name
-              dynamic "action_to_use" {
-                for_each = rule.value.st_override_actions
-                content {}
-              }
+              name = excluded_rule.value
             }
           }
+
+#          dynamic "rule_action_override" {
+#            for_each = rule.value.st_override_actions
+#            content {
+#              name = rule.value.name
+#              dynamic "action_to_use" {
+#                for_each = rule.value.st_override_actions
+#                content {}
+#              }
+#            }
+#          }
         }
       }
 

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -85,6 +85,6 @@ resource "aws_wafv2_web_acl_association" "fg_waf_to_alb" {
 resource "aws_wafv2_web_acl_logging_configuration" "fg_logging_waf" {
   count = var.enable_logging ? 1 : 0
 
-  log_destination_configs = var.storage_logs_arn
+  log_destination_configs = [var.storage_logs_arn]
   resource_arn            = aws_wafv2_web_acl.fg_web_acl_alb.arn
 }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -204,24 +204,6 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
       statement {
         rule_group_reference_statement {
           arn = rule.value.group_rule_arn
-
-#          dynamic "excluded_rule" {
-#            for_each = rule.value.excluded_rules
-#            content {
-#              name = excluded_rule.value
-#            }
-#          }
-#
-#          dynamic "rule_action_override" {
-#            for_each = rule.value.st_override_actions
-#            content {
-#              name = rule.value.name
-#              dynamic "action_to_use" {
-#                for_each = rule.value.st_override_actions
-#                content {}
-#              }
-#            }
-#          }
         }
       }
 

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -211,17 +211,17 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 #              name = excluded_rule.value
 #            }
 #          }
-
-          dynamic "rule_action_override" {
-            for_each = rule.value.st_override_actions
-            content {
-              name = rule.value.name
-              dynamic "action_to_use" {
-                for_each = rule.value.st_override_actions
-                content {}
-              }
-            }
-          }
+#
+#          dynamic "rule_action_override" {
+#            for_each = rule.value.st_override_actions
+#            content {
+#              name = rule.value.name
+#              dynamic "action_to_use" {
+#                for_each = rule.value.st_override_actions
+#                content {}
+#              }
+#            }
+#          }
         }
       }
 

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -76,7 +76,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
   tags = var.tags
 }
 
-resource "aws_wafv2_web_acl_association" "example" {
+resource "aws_wafv2_web_acl_association" "fg_waf_to_alb" {
   web_acl_arn  = aws_wafv2_web_acl.fg_web_acl_alb.arn
   resource_arn = var.alb_arn
 }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -50,7 +50,10 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
             for_each = rule.value.override_action
             content {
               name = rule.value.name
-              action_to_use = rule.value.override_action
+              dynamic "action_to_use" {
+                for_each = rule.value.override_action == "none" ? [1] : []
+                  rule.value.override_action {}
+              }
             }
           }
         }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -68,14 +68,10 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
     content {
       name = rule.value.name
       priority = rule.value.priority
-      action {
-        rule.value.action
-      }
-      statement {
-        rule.value.statement
-      }
       visibility_config {
-        rule.value.visibility_config
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+        metric_name                = rule.value.metric_name
       }
     }
   }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -65,6 +65,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 
   dynamic "rule" {
     for_each = var.custom_rules
+    content {}
   }
 
   visibility_config {

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -65,7 +65,19 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 
   dynamic "rule" {
     for_each = var.custom_rules
-    content {}
+    content {
+      name = rule.value.name
+      priority = rule.value.priority
+      action {
+        rule.value.action
+      }
+      statement {
+        rule.value.statement
+      }
+      visibility_config {
+        rule.value.visibility_config
+      }
+    }
   }
 
   visibility_config {

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -46,16 +46,18 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
           name        = rule.value.name
           vendor_name = rule.value.vendor_name
 
-          dynamic "rule_action_override" {
-            for_each = rule.value.st_override_actions
-            content {
-              name = rule.value.name
-              dynamic "action_to_use" {
-                for_each = rule.value.st_override_actions
-                content {}
-              }
-            }
-          }
+          excluded_rule {}
+
+#          dynamic "rule_action_override" {
+#            for_each = rule.value.st_override_actions
+#            content {
+#              name = rule.value.name
+#              dynamic "action_to_use" {
+#                for_each = rule.value.st_override_actions
+#                content {}
+#              }
+#            }
+#          }
         }
       }
 

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -71,7 +71,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
       visibility_config {
         cloudwatch_metrics_enabled = false
         sampled_requests_enabled   = false
-        metric_name                = rule.value.metric_name
+        metric_name                = rule.value.visibility_config_metric_name
       }
     }
   }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -47,16 +47,12 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
           vendor_name = rule.value.vendor_name
 
           dynamic "rule_action_override" {
-            for_each = rule.value.override_action
+            for_each = rule.value.st_override_actions
             content {
               name = rule.value.name
               dynamic "action_to_use" {
-                for_each = rule.value.override_action == "none" ? [1] : []
-                  content {}
-              }
-              dynamic "action_to_use" {
-                for_each = rule.value.override_action == "count" ? [1] : []
-                  content {}
+                for_each = rule.value.st_override_actions
+                content {}
               }
             }
           }
@@ -71,7 +67,7 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
     }
   }
 
-dynamic "rule" {
+  dynamic "rule" {
     for_each = var.ip_sets_rules
     content {
       name     = rule.value.name
@@ -210,10 +206,13 @@ dynamic "rule" {
           arn = rule.value.group_rule_arn
 
           dynamic "rule_action_override" {
-            for_each = rule.value.override_action
+            for_each = rule.value.st_override_actions
             content {
               name = rule.value.name
-              action_to_use = rule.value.override_action
+              dynamic "action_to_use" {
+                for_each = rule.value.st_override_actions
+                content {}
+              }
             }
           }
         }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -57,10 +57,14 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
 
       visibility_config {
         cloudwatch_metrics_enabled = true
-        metric_name                = rule.value.name
         sampled_requests_enabled   = true
+        metric_name                = rule.value.name
       }
     }
+  }
+
+  dynamic "rule" {
+    for_each = var.custom_rules
   }
 
   visibility_config {
@@ -70,4 +74,16 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
   }
 
   tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "example" {
+  web_acl_arn  = aws_wafv2_web_acl.fg_web_acl_alb.arn
+  resource_arn = var.alb_arn
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "fg_logging_waf" {
+  count = enable_logging ? 1 : 0
+
+  log_destination_configs = var.storage_logs_arn
+  resource_arn            = aws_wafv2_web_acl.fg_web_acl_alb.arn
 }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -46,10 +46,11 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
           name        = rule.value.name
           vendor_name = rule.value.vendor_name
 
-          dynamic "excluded_rule" {
-            for_each = rule.value.excluded_rules
+          dynamic "rule_action_override" {
+            for_each = rule.value.override_action
             content {
-              name = excluded_rule.value
+              name = rule.value.name
+              action_to_use = rule.value.override_action
             }
           }
         }
@@ -201,10 +202,11 @@ dynamic "rule" {
         rule_group_reference_statement {
           arn = rule.value.group_rule_arn
 
-          dynamic "excluded_rule" {
-            for_each = rule.value.excluded_rules
+          dynamic "rule_action_override" {
+            for_each = rule.value.override_action
             content {
-              name = excluded_rule.value
+              name = rule.value.name
+              action_to_use = rule.value.override_action
             }
           }
         }

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -1,0 +1,73 @@
+resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
+  name        = var.name
+  description = var.description
+  scope       = "REGIONAL"
+
+  default_action {
+    dynamic "allow" {
+      for_each = var.default_action == "allow" ? [1] : []
+      content {}
+    }
+    dynamic "block" {
+      for_each = var.default_action == "block" ? [1] : []
+      content {}
+    }
+  }
+
+  dynamic "custom_response_body" {
+    for_each = var.custom_responses
+    content {
+      key          = custom_responses.value.key
+      content      = custom_responses.value.content
+      content_type = custom_responses.value.content_type
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.managed_rules
+    content {
+      name     = rule.value.name
+      priority = rule.value.priority
+
+      override_action {
+        dynamic "none" {
+          for_each = rule.value.override_action == "none" ? [1] : []
+          content {}
+        }
+
+        dynamic "count" {
+          for_each = rule.value.override_action == "count" ? [1] : []
+          content {}
+        }
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = rule.value.name
+          vendor_name = rule.value.vendor_name
+
+          dynamic "excluded_rule" {
+            for_each = rule.value.excluded_rules
+            content {
+              name = excluded_rule.value
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = rule.value.name
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = var.enable_cloudwatch
+    sampled_requests_enabled   = var.enable_sampled_requests
+    metric_name                = var.metric_name
+  }
+
+  tags = var.tags
+}

--- a/aws/waf-acl-alb/main.tf
+++ b/aws/waf-acl-alb/main.tf
@@ -205,23 +205,23 @@ resource "aws_wafv2_web_acl" "fg_web_acl_alb" {
         rule_group_reference_statement {
           arn = rule.value.group_rule_arn
 
-          dynamic "excluded_rule" {
-            for_each = rule.value.excluded_rules
-            content {
-              name = excluded_rule.value
-            }
-          }
-
-#          dynamic "rule_action_override" {
-#            for_each = rule.value.st_override_actions
+#          dynamic "excluded_rule" {
+#            for_each = rule.value.excluded_rules
 #            content {
-#              name = rule.value.name
-#              dynamic "action_to_use" {
-#                for_each = rule.value.st_override_actions
-#                content {}
-#              }
+#              name = excluded_rule.value
 #            }
 #          }
+
+          dynamic "rule_action_override" {
+            for_each = rule.value.st_override_actions
+            content {
+              name = rule.value.name
+              dynamic "action_to_use" {
+                for_each = rule.value.st_override_actions
+                content {}
+              }
+            }
+          }
         }
       }
 

--- a/aws/waf-acl-alb/outputs.tf
+++ b/aws/waf-acl-alb/outputs.tf
@@ -1,0 +1,15 @@
+output "web_acl_id" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.id, "")
+}
+
+output "web_acl_arn" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.arn, "")
+}
+
+output "web_acl_capacity" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.capacity, "")
+}
+
+output "web_acl_tags" {
+  value = try(aws_wafv2_web_acl.fg_web_acl_alb.tags_all, "")
+}

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -1,0 +1,100 @@
+variable "name" {
+  description = "Name of the WEB ACL"
+  type        = string
+}
+
+variable "description" {
+  description = "Something meaningful to describe this ACL"
+  type        = string
+}
+
+variable "default_action" {
+  description = "Action to apply if no rules match"
+  type        = string
+  default     = "allow"
+}
+
+variable "alb_arn" {
+  description = "ARN of the Application LB to associate with"
+  type        = string
+}
+
+variable "enable_logging" {
+  description = "Log all traffic through the ACL"
+  type        = bool
+  default     = false
+}
+
+variable "enable_cloudwatch" {
+  description = "Enable metrics for the ACL"
+  type        = bool
+  default     = false
+}
+
+variable "enable_sampled_requests" {
+  description = "Enable sampled requests for the ACL"
+  type        = bool
+  default     = false
+}
+
+variable "metric_name" {
+  description = "The name of the metric to create, if we are enabling CloudWatch"
+  type        = string
+  default     = ""
+}
+
+variable "managed_rules" {
+  type = list(object({
+    name            = string
+    priority        = number
+    override_action = string
+    excluded_rules  = list(string)
+    vendor_name     = string
+  }))
+  description = "List of Managed WAF rules."
+  default = [
+    {
+      name            = "AWSManagedRulesCommonRuleSet",
+      priority        = 10
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesAmazonIpReputationList",
+      priority        = 20
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesKnownBadInputsRuleSet",
+      priority        = 30
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesSQLiRuleSet",
+      priority        = 40
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesLinuxRuleSet",
+      priority        = 50
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    },
+    {
+      name            = "AWSManagedRulesUnixRuleSet",
+      priority        = 60
+      override_action = "none"
+      excluded_rules  = []
+      vendor_name     = "AWS"
+    }
+  ]
+}
+

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -44,7 +44,7 @@ variable "metric_name" {
 }
 
 variable "tags" {
-  descriotion = "Useful to diferentiate resources per env, team, function ..."
+  description = "Useful to diferentiate resources per env, team, function ..."
   type        = map(any)
   default     = {}
 }

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -67,7 +67,7 @@ variable "custom_responses" {
 
 variable "custom_rules" {
   description = "Add here all the rules as a list of maps"
-  type        = list
+  type        = any
   default     = []
 }
 

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -46,7 +46,7 @@ variable "enable_sampled_requests" {
 variable "metric_name" {
   description = "The name of the metric to create, if we are enabling CloudWatch"
   type        = string
-  default     = "FG_WEBACL_ALB_Entityx"
+  default     = "FG_WEBACL_ALB"
 }
 
 variable "tags" {

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -91,48 +91,55 @@ variable "group_rules" {
 
 variable "managed_rules" {
   type = list(object({
-    name            = string
-    priority        = number
-    override_action = string
-    vendor_name     = string
+    name                = string
+    priority            = number
+    override_action     = string
+    st_override_actions = list(string)
+    vendor_name         = string
   }))
   description = "List of Managed WAF rules."
   default = [
     {
-      name            = "AWSManagedRulesCommonRuleSet",
-      priority        = 10
-      override_action = "none"
-      vendor_name     = "AWS"
+      name                = "AWSManagedRulesCommonRuleSet",
+      priority            = 10
+      override_action     = "none"
+      st_override_actions = []
+      vendor_name         = "AWS"
     },
     {
-      name            = "AWSManagedRulesAmazonIpReputationList",
-      priority        = 20
-      override_action = "none"
-      vendor_name     = "AWS"
+      name                = "AWSManagedRulesAmazonIpReputationList",
+      priority            = 20
+      override_action     = "none"
+      st_override_actions = []
+      vendor_name         = "AWS"
     },
     {
-      name            = "AWSManagedRulesKnownBadInputsRuleSet",
-      priority        = 30
-      override_action = "none"
-      vendor_name     = "AWS"
+      name                = "AWSManagedRulesKnownBadInputsRuleSet",
+      priority            = 30
+      override_action     = "none"
+      st_override_actions = []
+      vendor_name         = "AWS"
     },
     {
-      name            = "AWSManagedRulesSQLiRuleSet",
-      priority        = 40
-      override_action = "none"
-      vendor_name     = "AWS"
+      name                = "AWSManagedRulesSQLiRuleSet",
+      priority            = 40
+      override_action     = "none"
+      st_override_actions = []
+      vendor_name         = "AWS"
     },
     {
-      name            = "AWSManagedRulesLinuxRuleSet",
-      priority        = 50
-      override_action = "none"
-      vendor_name     = "AWS"
+      name                = "AWSManagedRulesLinuxRuleSet",
+      priority            = 50
+      override_action     = "none"
+      st_override_actions = []
+      vendor_name         = "AWS"
     },
     {
-      name            = "AWSManagedRulesUnixRuleSet",
-      priority        = 60
-      override_action = "none"
-      vendor_name     = "AWS"
+      name                = "AWSManagedRulesUnixRuleSet",
+      priority            = 60
+      override_action     = "none"
+      st_override_actions = []
+      vendor_name         = "AWS"
     }
   ]
 }

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -43,6 +43,12 @@ variable "metric_name" {
   default     = ""
 }
 
+variable "tags" {
+  descriotion = "Useful to diferentiate resources per env, team, function ..."
+  type        = map(any)
+  default     = {}
+}
+
 variable "managed_rules" {
   type = list(object({
     name            = string

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -49,6 +49,16 @@ variable "tags" {
   default     = {}
 }
 
+variable "custom_responses" {
+  description = "The custom response behaviour for the default web ACL action"
+  type = list(object({
+    key          = string
+    content      = string
+    content_type = string
+  }))
+  default = []
+}
+
 variable "managed_rules" {
   type = list(object({
     name            = string

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -67,7 +67,7 @@ variable "custom_responses" {
 
 variable "custom_rules" {
   description = "Add here all the rules as a list of maps"
-  type        = list(string)
+  type        = list
   default     = []
 }
 

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -40,7 +40,7 @@ variable "enable_sampled_requests" {
 variable "metric_name" {
   description = "The name of the metric to create, if we are enabling CloudWatch"
   type        = string
-  default     = ""
+  default     = "FG_WEBACL_ALB_Entityx"
 }
 
 variable "tags" {

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -25,6 +25,12 @@ variable "enable_logging" {
   default     = false
 }
 
+variable "storage_logs_arn" {
+  description = "ARN of the destination of the logs. It can be S3, CW or Kinesis"
+  type        = string
+  default     = ""
+}
+
 variable "enable_cloudwatch" {
   description = "Enable metrics for the ACL"
   type        = bool

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -94,7 +94,6 @@ variable "managed_rules" {
     name            = string
     priority        = number
     override_action = string
-    excluded_rules  = list(string)
     vendor_name     = string
   }))
   description = "List of Managed WAF rules."
@@ -103,42 +102,36 @@ variable "managed_rules" {
       name            = "AWSManagedRulesCommonRuleSet",
       priority        = 10
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesAmazonIpReputationList",
       priority        = 20
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesKnownBadInputsRuleSet",
       priority        = 30
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesSQLiRuleSet",
       priority        = 40
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesLinuxRuleSet",
       priority        = 50
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     },
     {
       name            = "AWSManagedRulesUnixRuleSet",
       priority        = 60
       override_action = "none"
-      excluded_rules  = []
       vendor_name     = "AWS"
     }
   ]

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -65,8 +65,26 @@ variable "custom_responses" {
   default = []
 }
 
-variable "custom_rules" {
-  description = "Add here all the rules as a list of maps"
+variable "ip_sets_rules" {
+  description = "Add here rules for ip_sets, if any"
+  type        = any
+  default     = []
+}
+
+variable "ip_rate_based_rules" {
+  description = "Add here rules for ip_sets, if any"
+  type        = any
+  default     = []
+}
+
+variable "ip_rate_url_based_rules" {
+  description = "Add here rules for ip_sets, if any"
+  type        = any
+  default     = []
+}
+
+variable "group_rules" {
+  description = "Add here rules for ip_sets, if any"
   type        = any
   default     = []
 }

--- a/aws/waf-acl-alb/variables.tf
+++ b/aws/waf-acl-alb/variables.tf
@@ -28,13 +28,13 @@ variable "enable_logging" {
 variable "enable_cloudwatch" {
   description = "Enable metrics for the ACL"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_sampled_requests" {
   description = "Enable sampled requests for the ACL"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "metric_name" {
@@ -57,6 +57,12 @@ variable "custom_responses" {
     content_type = string
   }))
   default = []
+}
+
+variable "custom_rules" {
+  description = "Add here all the rules as a list of maps"
+  type        = list(string)
+  default     = []
 }
 
 variable "managed_rules" {

--- a/aws/waf-acl-alb/versions.tf
+++ b/aws/waf-acl-alb/versions.tf
@@ -5,6 +5,6 @@ terraform {
       version = "4.58.0"
     }
   }
-  required_version = "~> 4.47.1"
+  required_version = "~> 1.4.0"
 }
 

--- a/aws/waf-acl-alb/versions.tf
+++ b/aws/waf-acl-alb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.58.0"
+    }
+  }
+  required_version = "~> 4.47.1"
+}
+


### PR DESCRIPTION
Requires:
	•	Name for the Web ACL
	•	Description for the Web ACL
	•	ARN of an existing ALB
Defaults:
	•	default action: allow
	•	Logs are disabled by default: it will require the arn of an s3,Cloudwatch LG, Kinesis when enabled
	•	Cloudwatch is enabled by default
	•	Sampled requests are enabled by default
	•	It creates a Metric with suffix: FG_WEBACL_ALB
Creates:
	•	Web ACL
	◦	Accepts a list of AWS Managed rules, defaults to the full list of managed rules
	◦	Accepts a list of rules of the following types:
	▪	ip sets
	▪	ip rate
	▪	ip rate URLs
	▪	Group rules
	•	Association with an existing ALB
	•	Logging configuration
