### PR TITLE
fix: AWS - Associate key pair with instance

### DIFF
--- a/aws/ec2-instance/main.tf
+++ b/aws/ec2-instance/main.tf
@@ -133,6 +133,7 @@ resource "aws_instance" "fg" {
   monitoring              = true
   user_data               = var.user_data
   vpc_security_group_ids  = [aws_security_group.fg.id]
+  key_name                = aws_key_pair.deployer.key_name
 
   tags = merge(
     { "Name" = "${var.vpc_name}-ec2-instance-${count.index + 1}-${var.env}", },


### PR DESCRIPTION
Ties the existing deployed key pair to the ec2 instance with key_name attribute.