### PR TITLE
fix: AWS - Restrict external NLBs to only https

### DIFF
--- a/aws/net-lb/outputs.tf
+++ b/aws/net-lb/outputs.tf
@@ -88,12 +88,12 @@ output "default_nlb_target_group_tags" {
 
 output "nlb_listener_http_arn" {
   description = "ARN or ID of the Network Load Balancer's HTTP listener."
-  value       = try(aws_lb_listener.http.arn, "")
+  value       = try(aws_lb_listener.http[0].arn, "")
 }
 
 output "nlb_listener_http_tags" {
   description = "Map with all tags for the HTTP listener."
-  value       = try(aws_lb_listener.http.tags_all, "")
+  value       = try(aws_lb_listener.http[0].tags_all, "")
 }
 
 output "nlb_listener_https_arn" {

--- a/aws/net-lb/variables.tf
+++ b/aws/net-lb/variables.tf
@@ -50,13 +50,26 @@ variable "default_target_group_protocol" {
 
 ## Health Check
 
-variable "health_check" {
+variable "health_check_80" {
   type        = map(string)
-  description = "Map describing Health Check settings - including endpoint (default /) and port (default 80)."
+  description = "Map describing Health Check settings - including endpoint (default /) and port (default 80). Applied for internal NLBs."
   default = {
     timeout             = "10"
     interval            = "20"
     port                = "80"
+    protocol            = "TCP"
+    unhealthy_threshold = "2"
+    healthy_threshold   = "3"
+  }
+}
+
+variable "health_check_443" {
+  type        = map(string)
+  description = "Map describing Health Check settings - including endpoint (default /) and port (default 443). Applied for external NLBs."
+  default = {
+    timeout             = "10"
+    interval            = "20"
+    port                = "443"
     protocol            = "TCP"
     unhealthy_threshold = "2"
     healthy_threshold   = "3"


### PR DESCRIPTION
Draft PR to be merged after demo.

Restricts external NLB security group rules and listeners to only use HTTPS protocol.