### PR TITLE
fix: AWS - allow egress traffic from ec2 to anywhere

### DIFF
--- a/aws/ec2-instance/README.md
+++ b/aws/ec2-instance/README.md
@@ -37,7 +37,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | The number of requested Availability Zones | `number` | `1` | no |
 | <a name="input_ec2_count"></a> [ec2\_count](#input\_ec2\_count) | The number of requested EC2 instances. | `number` | `1` | no |
-| <a name="input_egress_ip_address"></a> [egress\_ip\_address](#input\_egress\_ip\_address) | IP address to allow HTTPS access to | `string` | `"10.10.0.0/16"` | no |
+| <a name="input_egress_ip_address"></a> [egress\_ip\_address](#input\_egress\_ip\_address) | Allow outgoing traffic from the ec2 to anywhere | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment: dev, test, stg, prod | `string` | `"dev"` | no |
 | <a name="input_http_ingress_ip_address"></a> [http\_ingress\_ip\_address](#input\_http\_ingress\_ip\_address) | IP address to allow HTTP access from | `string` | `"10.10.0.0/16"` | no |
 | <a name="input_https_ingress_ip_address"></a> [https\_ingress\_ip\_address](#input\_https\_ingress\_ip\_address) | IP address to allow HTTPS access from | `string` | `"10.10.0.0/16"` | no |

--- a/aws/ec2-instance/variables.tf
+++ b/aws/ec2-instance/variables.tf
@@ -46,8 +46,8 @@ variable "ssh_ingress_ip_address" {
 
 variable "egress_ip_address" {
   type        = string
-  description = "IP address to allow HTTPS access to"
-  default     = "10.10.0.0/16"
+  description = "Allow outgoing traffic from the ec2 to anywhere"
+  default     = "0.0.0.0/0"
 }
 
 # EC2 Instance


### PR DESCRIPTION
We will allow the creation of NAT gws, and then we need the ec2 instances to be able to initiate requests to anywhere